### PR TITLE
remove config path from vault

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,7 +12,7 @@ import yaml
 app = Flask(__name__, static_folder='/backend/static', static_url_path='/')
 api = Api(app)
 
-with open(os.environ.get('CONFIG_PATH')) as f:
+with open(os.environ.get('CONFIG_PATH') + "/config.yaml") as f:
     config = yaml.load(f, Loader=yaml.FullLoader)
     app.config.update(config)
 app.config['BASIC_AUTH_USERNAME'] = app.config.get('basic_auth', {}).get('username')

--- a/openshift.yml
+++ b/openshift.yml
@@ -10,10 +10,13 @@ parameters:
   value: "quay.io/app-sre/quayio-service-tool"
   required: true
 - name: IMAGE_TAG
-  value: "latest"
+  value: ""
   required: true
 - name: ACTIVE_DEADLINE_SECONDS
   value: "600"
+  required: true
+- name: CONFIG_MOUNT_PATH
+  value: "/config"
   required: true
 objects:
 - apiVersion: apps/v1
@@ -35,7 +38,7 @@ objects:
           image: ${IMAGE}:${IMAGE_TAG}
           volumeMounts:
           - name: config
-            mountPath: "/config"
+            mountPath: ${{CONFIG_MOUNT_PATH}}
             readOnly: true
           ports:
           - containerPort: 5000
@@ -48,10 +51,7 @@ objects:
               memory: 128Mi
           env:
           - name: CONFIG_PATH
-            valueFrom:
-              secretKeyRef:
-                name: ${{QUAY_SERVICE_TOOL_CONFIG_SECRET}}
-                key: config_path
+            value: ${{CONFIG_MOUNT_PATH}}
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Update so we can remove config-path from quay-service-tool-config-secret.yaml in app-interface as suggested.