### PR TITLE
add labels to deployment metadata

### DIFF
--- a/openshift.yml
+++ b/openshift.yml
@@ -23,7 +23,12 @@ objects:
   kind: Deployment
   metadata:
     name: quayio-service-tool
+    labels:
+      app: quayio-service-tool
   spec:
+    selector:
+      matchLabels:
+        app: quayio-service-tool
     template:
       metadata:
         labels:


### PR DESCRIPTION
Fix the staging error: 
The Deployment “quayio-service-tool” is invalid:
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: map[string]string{“app”:“quayio-service-tool”}: `selector` does not match template `labels`