### PR TITLE
Adding Export Compliance tab and fetching quay user details (PROJQUAY-4173)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod -R ug+rwx /frontend
 WORKDIR "$HOME"
 USER 1001
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 RUN npm run build
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,6 +7,7 @@ from prometheus_flask_exporter import PrometheusMetrics
 from urllib.parse import unquote
 from tasks.banner import BannerTask
 from tasks.username import UsernameTask
+from tasks.useremail import UseremailTask
 from tasks.user import UserTask
 import yaml
 import logging
@@ -91,6 +92,7 @@ def main():
 api.add_resource(BannerTask, '/banner', '/banner/<int:id>', endpoint='banner')
 api.add_resource(UsernameTask, '/username')
 api.add_resource(UserTask, '/user/<username>')
+api.add_resource(UseremailTask, '/fetchuser/<useremail>')
 
 
 if __name__ == '__main__':

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,8 +7,8 @@ from prometheus_flask_exporter import PrometheusMetrics
 from urllib.parse import unquote
 from tasks.banner import BannerTask
 from tasks.username import UsernameTask
-from tasks.useremail import UseremailTask
-from tasks.user import UserTask
+from tasks.federateduser import FederatedUserTask
+from tasks.user import UserTask, FetchUserFromEmailTask, FetchUserFromNameTask
 import yaml
 import logging
 from utils import *
@@ -97,7 +97,9 @@ def main():
 api.add_resource(BannerTask, '/banner', '/banner/<int:id>', endpoint='banner')
 api.add_resource(UsernameTask, '/username')
 api.add_resource(UserTask, '/user/<username>')
-api.add_resource(UseremailTask, '/fetchuser/<useremail>')
+api.add_resource(FetchUserFromNameTask, '/quayusername/<quayusername>')
+api.add_resource(FetchUserFromEmailTask, '/quayuseremail/<quayuseremail>')
+api.add_resource(FederatedUserTask, '/federateduser/<username>')
 
 
 if __name__ == '__main__':

--- a/backend/app.py
+++ b/backend/app.py
@@ -91,7 +91,10 @@ def main():
     AUTH_URL = app.config.get('authentication', {}).get('url')
     AUTH_REALM = app.config.get('authentication', {}).get('realm')
     AUTH_CLIENTID = app.config.get('authentication', {}).get('clientid')
-    return render_template('index.html', AUTH_URL=AUTH_URL,  AUTH_REALM=AUTH_REALM, AUTH_CLIENTID=AUTH_CLIENTID)
+    ADMIN_ROLE = app.config.get('authentication', {}).get('roles', {}).get('ADMIN_ROLE')
+    EXPORT_COMPLIANCE_ROLE = app.config.get('authentication', {}).get('roles', {}).get('EXPORT_COMPLIANCE_ROLE')
+    return render_template('index.html', AUTH_URL=AUTH_URL,  AUTH_REALM=AUTH_REALM, AUTH_CLIENTID=AUTH_CLIENTID,
+                           ADMIN_ROLE=ADMIN_ROLE, EXPORT_COMPLIANCE_ROLE=EXPORT_COMPLIANCE_ROLE,)
 
 
 api.add_resource(BannerTask, '/banner', '/banner/<int:id>', endpoint='banner')

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -6,13 +6,14 @@ is_local: true
 
 # Used to test authentication in local env
 test_auth: true
-
 authentication:
   url: http://host.docker.internal:8081/auth
   # If keycloak is run outside a container
 #  url: http://localhost:8081/auth/
   realm: Test
   clientid: test-client-id
-  roles: ['admin-role', 'export-compliance-role']
+  roles:
+    ADMIN_ROLE: 'admin-role'
+    EXPORT_COMPLIANCE_ROLE: 'export-compliance-role'
 ENV: development
 DEBUG: true

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -1,10 +1,16 @@
 DATABASE_SECRET_KEY: 'randomkey'
 DB_URI: postgresql://quay:quay@host.docker.internal:5432/quay
-# If backend is run outside a container:
-# DB_URI: postgresql://quay:quay@0.0.0.0:5432/quay
+# If service tool backend is run outside a container:
+#DB_URI: postgresql://quay:quay@0.0.0.0:5432/quay
 is_local: true
+
+# Used to test authentication in local env
+test_auth: true
+
 authentication:
   url: http://host.docker.internal:8081/auth
+  # If keycloak is run outside a container
+#  url: http://localhost:8081/auth/
   realm: Test
   clientid: test-client-id
   role: admin-access

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -13,6 +13,6 @@ authentication:
 #  url: http://localhost:8081/auth/
   realm: Test
   clientid: test-client-id
-  role: admin-access
+  roles: ['admin-role', 'export-compliance-role']
 ENV: development
 DEBUG: true

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -1,15 +1,15 @@
 DATABASE_SECRET_KEY: 'randomkey'
-#DB_URI: postgresql://quay:quay@host.docker.internal:5432/quay
+DB_URI: postgresql://quay:quay@host.docker.internal:5432/quay
 # If service tool backend is run outside a container:
-DB_URI: postgresql://quay:quay@0.0.0.0:5432/quay
+#DB_URI: postgresql://quay:quay@0.0.0.0:5432/quay
 is_local: true
 
 # Used to test authentication in local env
 test_auth: true
 authentication:
-#  url: http://host.docker.internal:8081/auth
+  url: http://host.docker.internal:8081/auth
   # If keycloak is run outside a container
-  url: http://localhost:8081/auth/
+#  url: http://localhost:8081/auth/
   realm: Test
   clientid: test-client-id
   roles:

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -1,15 +1,15 @@
 DATABASE_SECRET_KEY: 'randomkey'
-DB_URI: postgresql://quay:quay@host.docker.internal:5432/quay
+#DB_URI: postgresql://quay:quay@host.docker.internal:5432/quay
 # If service tool backend is run outside a container:
-#DB_URI: postgresql://quay:quay@0.0.0.0:5432/quay
+DB_URI: postgresql://quay:quay@0.0.0.0:5432/quay
 is_local: true
 
 # Used to test authentication in local env
 test_auth: true
 authentication:
-  url: http://host.docker.internal:8081/auth
+#  url: http://host.docker.internal:8081/auth
   # If keycloak is run outside a container
-#  url: http://localhost:8081/auth/
+  url: http://localhost:8081/auth/
   realm: Test
   clientid: test-client-id
   roles:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,7 +30,7 @@ python-jose==3.3.0
 python-keycloak==0.24
 pytz==2021.3
 PyYAML==5.4
-requests==2.22.0
+requests==2.27.1
 rfc3986==1.5.0
 rsa==4.7.2
 six==1.14.0
@@ -38,7 +38,7 @@ sniffio==1.2.0
 supervisor==4.2.0
 supervisor-logging==0.0.9
 supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380
-urllib3==1.25.8
+urllib3==1.26.9
 Werkzeug==1.0.0
 zope.event==4.5.0
 zope.interface==5.4.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/quay/quay@fd190ad98468bbeb911bc2327faec14e84764265#egg=quay
+git+https://github.com/quay/quay@adf709568eb84a473b2924b1e5adedf457c86813#egg=quay
 aniso8601==9.0.1
 anyio==3.3.4
 cached-property==1.5.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,7 +39,7 @@ supervisor==4.2.0
 supervisor-logging==0.0.9
 supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380
 urllib3==1.25.8
-Werkzeug==0.16.1
+Werkzeug==1.0.0
 zope.event==4.5.0
 zope.interface==5.4.0
 text_unidecode==1.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/quay/quay@1e136d6dd0fec70cb6e4cbd442ef1768aab1592d#egg=quay
+git+https://github.com/quay/quay@7c566ad4f3879e08ed82955a14122cd2a2e1f269#egg=quay
 aniso8601==9.0.1
 anyio==3.3.4
 cached-property==1.5.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/quay/quay@adf709568eb84a473b2924b1e5adedf457c86813#egg=quay
+git+https://github.com/quay/quay@1e136d6dd0fec70cb6e4cbd442ef1768aab1592d#egg=quay
 aniso8601==9.0.1
 anyio==3.3.4
 cached-property==1.5.2

--- a/backend/tasks/banner.py
+++ b/backend/tasks/banner.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 from flask import make_response
 from flask_restful import reqparse
 from playhouse.shortcuts import model_to_dict
-from utils import is_valid_severity, log_response
+from utils import is_valid_severity, log_response, verify_admin_permissions
 import json
 from data.model import message, db_transaction
 from data.database import Messages
@@ -11,6 +11,7 @@ from data.database import Messages
 
 class BannerTask(Resource):
     @log_response
+    @verify_admin_permissions
     @login_required
     def get(self):
         try:
@@ -22,6 +23,7 @@ class BannerTask(Resource):
             )
 
     @log_response
+    @verify_admin_permissions
     @login_required
     def post(self):
         parser = reqparse.RequestParser()
@@ -53,6 +55,7 @@ class BannerTask(Resource):
             )
 
     @log_response
+    @verify_admin_permissions
     @login_required
     def put(self):
         parser = reqparse.RequestParser()
@@ -83,6 +86,7 @@ class BannerTask(Resource):
             )
 
     @log_response
+    @verify_admin_permissions
     @login_required
     def delete(self, id):
         try:

--- a/backend/tasks/federateduser.py
+++ b/backend/tasks/federateduser.py
@@ -1,0 +1,50 @@
+from flask_login import login_required
+from flask_restful import Resource
+from flask import make_response
+import json
+
+from utils import log_response, verify_export_compliance_permissions
+from data.model import user
+
+
+class FederatedUserTask(Resource):
+
+    @log_response
+    @verify_export_compliance_permissions
+    @login_required
+    def get(self, username):
+        if username is None:
+            return make_response(
+                json.dumps({"message": "`username` is required"}), 400
+            )
+        try:
+            found_user = user.get_quay_user_from_federated_login_name(username)
+            print("found_user", found_user.__dict__)
+            if found_user is None:
+                return make_response(
+                    json.dumps({"message": f"Could not find user with username `{username}`"}), 404
+                )
+            private_repo_count = user.get_private_repo_count(found_user.username)
+            public_repo_count = user.get_public_repo_count(found_user.username)
+
+            return make_response(
+                json.dumps({
+                    "username": found_user.username,
+                    "enabled": found_user.enabled,
+                    "paid_user": True if found_user.stripe_id else False,
+                    "last_accessed": str(found_user.last_accessed),
+                    "is_organization": found_user.organization,
+                    "company": found_user.company,
+                    "creation_date": str(found_user.creation_date),
+                    "last_accessed": str(found_user.last_accessed),
+                    "invoice_email": found_user.invoice_email,
+                    "private_repo_count": private_repo_count,
+                    "public_repo_count": public_repo_count,
+                }),
+                200,
+            )
+        # Same output for Quay username/email search.
+        except Exception:
+            return make_response(
+                json.dumps({"message": "Unable to fetch user"}), 500
+            )

--- a/backend/tasks/federateduser.py
+++ b/backend/tasks/federateduser.py
@@ -19,7 +19,6 @@ class FederatedUserTask(Resource):
             )
         try:
             found_user = user.get_quay_user_from_federated_login_name(username)
-            print("found_user", found_user.__dict__)
             if found_user is None:
                 return make_response(
                     json.dumps({"message": f"Could not find user with username `{username}`"}), 404

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -181,3 +181,61 @@ class UserTask(Resource):
         return make_response(
             json.dumps({"message": "User deleted successfully", "user": username}), 200
         )
+
+
+class FetchUserFromNameTask(Resource):
+    @log_response
+    @login_required
+    def get(self, quayusername):
+        if quayusername is None:
+            return make_response(
+                json.dumps({"message": "Parameter 'quay username' is required"}), 400
+            )
+        try:
+            found_user = user.get_namespace_user(quayusername)
+            if found_user is None:
+                return make_response(
+                    json.dumps({"message": f"Could not find user {quayusername}"}), 404
+                )
+
+            return make_response(
+                json.dumps({
+                    "email": found_user.email,
+                    "enabled": found_user.enabled,
+                    "last_accessed": str(found_user.last_accessed)
+                }),
+                200,
+            )
+        except Exception as e:
+            return make_response(
+                json.dumps({"message": f"Unable to fetch user {quayusername}"}), 500
+            )
+
+
+class FetchUserFromEmailTask(Resource):
+    @log_response
+    @login_required
+    def get(self, quayuseremail):
+        if quayuseremail is None:
+            return make_response(
+                json.dumps({"message": "Parameter 'quay useremail' is required"}), 400
+            )
+        try:
+            found_user = user.find_user_by_email(quayuseremail)
+            if found_user is None:
+                return make_response(
+                    json.dumps({"message": f"Could not find user {quayuseremail}"}), 404
+                )
+
+            return make_response(
+                json.dumps({
+                    "username": found_user.username,
+                    "enabled": found_user.enabled,
+                    "last_accessed": str(found_user.last_accessed)
+                }),
+                200,
+            )
+        except Exception as e:
+            return make_response(
+                json.dumps({"message": f"Unable to fetch user {quayuseremail}"}), 500
+            )

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -229,7 +229,7 @@ class FetchUserFromNameTask(Resource):
 
 class FetchUserFromEmailTask(Resource):
     @log_response
-    @verify_export_compliance_permissions
+    @verify_admin_permissions
     @login_required
     def get(self, quayuseremail):
         if quayuseremail is None:

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -198,11 +198,22 @@ class FetchUserFromNameTask(Resource):
                     json.dumps({"message": f"Could not find user {quayusername}"}), 404
                 )
 
+            private_repo_count = user.get_private_repo_count(found_user.username)
+            public_repo_count = user.get_public_repo_count(found_user.username)
+
             return make_response(
                 json.dumps({
                     "email": found_user.email,
                     "enabled": found_user.enabled,
-                    "last_accessed": str(found_user.last_accessed)
+                    "paid_user": True if found_user.stripe_id else False,
+                    "last_accessed": str(found_user.last_accessed),
+                    "is_organization": found_user.organization,
+                    "company": found_user.company,
+                    "creation_date": str(found_user.creation_date),
+                    "last_accessed": str(found_user.last_accessed),
+                    "invoice_email": found_user.invoice_email,
+                    "private_repo_count": private_repo_count,
+                    "public_repo_count": public_repo_count,
                 }),
                 200,
             )
@@ -226,12 +237,22 @@ class FetchUserFromEmailTask(Resource):
                 return make_response(
                     json.dumps({"message": f"Could not find user {quayuseremail}"}), 404
                 )
+            private_repo_count = user.get_private_repo_count(found_user.username)
+            public_repo_count = user.get_public_repo_count(found_user.username)
 
             return make_response(
                 json.dumps({
                     "username": found_user.username,
                     "enabled": found_user.enabled,
-                    "last_accessed": str(found_user.last_accessed)
+                    "paid_user": True if found_user.stripe_id else False,
+                    "last_accessed": str(found_user.last_accessed),
+                    "is_organization": found_user.organization,
+                    "company": found_user.company,
+                    "creation_date": str(found_user.creation_date),
+                    "last_accessed": str(found_user.last_accessed),
+                    "invoice_email": found_user.invoice_email,
+                    "private_repo_count": private_repo_count,
+                    "public_repo_count": public_repo_count,
                 }),
                 200,
             )

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -3,7 +3,7 @@ from flask_login import login_required
 from flask import make_response
 import json
 
-from utils import create_transaction as tf, log_response
+from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm
 from data.model import user, db_transaction
 from data.database import (
     Repository,
@@ -49,6 +49,7 @@ all_queues = [
 
 class UserTask(Resource):
     @log_response
+    @verify_admin_or_export_perm
     @login_required
     def get(self, username):
         if username is None or len(username) == 0:
@@ -76,6 +77,7 @@ class UserTask(Resource):
     # Used for enabling a user, under the general put function
     # Trying to keep this as RESTful as possible, but may want to separate out into it's own 'enable' endpoint
     @log_response
+    @verify_admin_or_export_perm
     @login_required
     def put(self, username):
         # Define params
@@ -167,6 +169,7 @@ class UserTask(Resource):
         )
 
     @log_response
+    @verify_admin_or_export_perm
     @login_required
     def delete(self, username):
         found_user = user.get_namespace_user(username)
@@ -185,6 +188,7 @@ class UserTask(Resource):
 
 class FetchUserFromNameTask(Resource):
     @log_response
+    @verify_admin_permissions
     @login_required
     def get(self, quayusername):
         if quayusername is None:
@@ -225,6 +229,7 @@ class FetchUserFromNameTask(Resource):
 
 class FetchUserFromEmailTask(Resource):
     @log_response
+    @verify_export_compliance_permissions
     @login_required
     def get(self, quayuseremail):
         if quayuseremail is None:

--- a/backend/tasks/username.py
+++ b/backend/tasks/username.py
@@ -4,12 +4,13 @@ from flask import make_response
 from flask_restful import reqparse
 from data import model
 from data.model import InvalidUsernameException, user
-from utils import log_response
+from utils import log_response, verify_admin_permissions
 import json
 
 
 class UsernameTask(Resource):
     @log_response
+    @verify_admin_permissions
     @login_required
     def put(self):
         parser = reqparse.RequestParser()

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -6,6 +6,8 @@
               var AUTH_URL = '{{ AUTH_URL }}';
               var AUTH_REALM = '{{ AUTH_REALM }}';
               var AUTH_CLIENTID = '{{ AUTH_CLIENTID }}';
+              var ADMIN_ROLE = '{{ ADMIN_ROLE }}';
+              var EXPORT_COMPLIANCE_ROLE = '{{ EXPORT_COMPLIANCE_ROLE }}';
         </script>
         <title>Quay Customer Service Tool</title>
         <meta id="appName" name="application-name" content="Quay Customer Service Tool">

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -26,7 +26,7 @@ class Auth(Resource):
 
         realm_access = token_info["realm_access"]
 
-        if not realm_access.get("roles") or config["role"] not in realm_access["roles"]:
+        if not realm_access.get("roles") or not (set(realm_access["roles"]) & set(config["roles"])):
             return User()
 
         return User(

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -25,8 +25,8 @@ class Auth(Resource):
             return User()
 
         realm_access = token_info["realm_access"]
-
-        if not realm_access.get("roles") or not (set(realm_access["roles"]) & set(config["roles"])):
+        if not realm_access.get("roles") or not config["roles"] or \
+           not (set(realm_access["roles"]) & set(config["roles"].values())):
             return User()
 
         return User(

--- a/frontend/.env
+++ b/frontend/.env
@@ -2,3 +2,5 @@ AUTH_REALM=Test
 AUTH_URL=http://localhost:8081/auth/
 AUTH_CLIENTID=test-client-id
 TEST_LOCAL_AUTH=true
+EXPORT_COMPLIANCE_ROLE=export-compliance-role
+ADMIN_ROLE=admin-role

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,4 @@
 AUTH_REALM=Test
-AUTH_URL=http://localhost:8081/auth
+AUTH_URL=http://localhost:8081/auth/
 AUTH_CLIENTID=test-client-id
+TEST_LOCAL_AUTH=true

--- a/frontend/src/app/AppLayout/AppLayout.tsx
+++ b/frontend/src/app/AppLayout/AppLayout.tsx
@@ -76,13 +76,16 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
 
   const location = useLocation();
 
-  const renderNavItem = (route: IAppRoute, index: number) => (
-    <NavItem key={`${route.label}-${index}`} id={`${route.label}-${index}`}>
-      <NavLink exact to={route.path} activeClassName="pf-m-current">
-        {route.label}
-      </NavLink>
-    </NavItem>
-  );
+  const renderNavItem = (route: IAppRoute, index: number) => {
+    const canView = route.permission ? UserService.hasRealmRole(route.permission) : true
+    return canView ? (
+      <NavItem key={`${route.label}-${index}`} id={`${route.label}-${index}`}>
+        <NavLink exact to={route.path} activeClassName="pf-m-current">
+          {route.label}
+        </NavLink>
+      </NavItem>
+    ) : null;
+  };
 
   const renderNavGroup = (group: IAppRouteGroup, groupIndex: number) => (
     <NavExpandable

--- a/frontend/src/app/ExportCompliance/ExportCompliance.tsx
+++ b/frontend/src/app/ExportCompliance/ExportCompliance.tsx
@@ -14,7 +14,7 @@ export const ExportCompliance: React.FunctionComponent = (props) => {
   const [userName, setUserName] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [message, setMessage] = useState('');
-  const [response, setResponse] = useState(false);
+  const [response, setResponse] = useState('');
 
   const userNameOnChange = (value) => {
     setUserName(value);

--- a/frontend/src/app/ExportCompliance/ExportCompliance.tsx
+++ b/frontend/src/app/ExportCompliance/ExportCompliance.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import {
+  ActionGroup, Button, Card,
+  CardBody,
+  CardTitle, Form, FormGroup, Modal, ModalVariant,
+  PageSection, TextInput, TextContent, TextListVariants,
+  TextList, TextListItem, TextListItemVariants
+} from '@patternfly/react-core';
+import {useState} from "react";
+import HttpService from "../../services/HttpService";
+
+export const ExportCompliance: React.FunctionComponent = (props) => {
+  const [userEmail, setUserEmail] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [response, setResponse] = useState(false);
+
+  async function fetchUser() {
+    if (userEmail != '') {
+       HttpService.axiosClient.get(`/fetchuser/${userEmail}`)
+      .then(function (response) {
+        setResponse(response.data);
+        console.log("response", response.data);
+      })
+      .catch(function (error) {
+        setMessage(error.response.data.message);
+        setIsModalOpen(true);
+      });
+    }
+  }
+
+  return (
+    <PageSection>
+      <Modal
+        isOpen={isModalOpen}
+        variant={ModalVariant.small}
+        aria-label="feedback modal"
+        showClose={true}
+        aria-describedby="no-header-example"
+        onClose={() => {
+          setIsModalOpen(!isModalOpen);
+        }}
+      >
+        <span>{message}</span>
+      </Modal>
+      <Card>
+        <CardTitle className={'text-uppercase'}> Fetch User details </CardTitle>
+        <CardBody>
+          <Form>
+            <FormGroup label="User email" fieldId="user-email" isRequired>
+              <TextInput
+                isRequired
+                type="text"
+                id="user-email"
+                name="user-email"
+                value={userEmail}
+                onChange={(value) => setUserEmail(value)}
+                placeholder="User email"
+              />
+            </FormGroup>
+
+            { response ? (
+              <TextContent>
+                <TextList component={TextListVariants.dl}>
+                  <TextListItem component={TextListItemVariants.dt}>Quay.io Username</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>
+                    {response.username}
+                  </TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Enabled</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>
+                    {response.enabled ? 'True' : 'False'}
+                  </TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Last Accessed</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>
+                    {response.last_accessed}
+                  </TextListItem>
+                </TextList>
+              </TextContent>) : null
+            }
+
+            <ActionGroup>
+              <Button variant="primary" onClick={fetchUser}>
+                Fetch User
+              </Button>
+            </ActionGroup>
+          </Form>
+        </CardBody>
+      </Card>
+    </PageSection>
+  );
+}

--- a/frontend/src/app/ExportCompliance/ExportCompliance.tsx
+++ b/frontend/src/app/ExportCompliance/ExportCompliance.tsx
@@ -8,6 +8,7 @@ import {
 } from '@patternfly/react-core';
 import {useState} from "react";
 import HttpService from "src/services/HttpService";
+import { DisableUser } from "src/app/UserUtils/actions/DisableUser";
 
 export const ExportCompliance: React.FunctionComponent = (props) => {
   const [userName, setUserName] = useState('');
@@ -36,64 +37,87 @@ export const ExportCompliance: React.FunctionComponent = (props) => {
   }
 
   return (
-    <PageSection>
-      <Modal
-        isOpen={isModalOpen}
-        variant={ModalVariant.small}
-        aria-label="feedback modal"
-        showClose={true}
-        aria-describedby="no-header-example"
-        onClose={() => {
-          setIsModalOpen(!isModalOpen);
-        }}
-      >
-        <span>{message}</span>
-      </Modal>
-      <Card>
-        <CardTitle className={'text-uppercase'}> Fetch User details </CardTitle>
-        <CardBody>
-          <Form>
-            <FormGroup label="User name" fieldId="user-name" isRequired>
-              <TextInput
-                isRequired
-                type="text"
-                id="user-name"
-                name="user-name"
-                value={userName}
-                onChange={(value) => userNameOnChange(value)}
-                placeholder="User name"
-              />
-            </FormGroup>
+    <div>
+      <PageSection>
+        <Modal
+          isOpen={isModalOpen}
+          variant={ModalVariant.small}
+          aria-label="feedback modal"
+          showClose={true}
+          aria-describedby="no-header-example"
+          onClose={() => {
+            setIsModalOpen(!isModalOpen);
+          }}
+        >
+          <span>{message}</span>
+        </Modal>
+        <Card>
+          <CardTitle className={'text-uppercase'}> Fetch User details </CardTitle>
+          <CardBody>
+            <Form>
+              <FormGroup label="User name" fieldId="user-name" isRequired>
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="user-name"
+                  name="user-name"
+                  value={userName}
+                  onChange={(value) => userNameOnChange(value)}
+                  placeholder="Red Hat Account Name"
+                />
+              </FormGroup>
 
-            { response ? (
-              <TextContent>
-                <TextList component={TextListVariants.dl}>
-                  <TextListItem component={TextListItemVariants.dt}>Quay.io Username</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.username}
-                  </TextListItem>
+              { response ? (
+                <TextContent>
+                  <TextList component={TextListVariants.dl}>
+                    <TextListItem component={TextListItemVariants.dt}>Quay.io Username</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      {response.username}
+                    </TextListItem>
 
-                  <TextListItem component={TextListItemVariants.dt}>Enabled</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.enabled ? 'True' : 'False'}
-                  </TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>Enabled</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.enabled.toString()}</TextListItem>
 
-                  <TextListItem component={TextListItemVariants.dt}>Last Accessed</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.last_accessed}
-                  </TextListItem>
-                </TextList>
-              </TextContent>) : null
-            }
+                    <TextListItem component={TextListItemVariants.dt}>Is Paid User</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.paid_user.toString()}</TextListItem>
 
-            <ActionGroup>
-              <Button variant="primary" onClick={fetchUser}>
-                Fetch User
-              </Button>
-            </ActionGroup>
-          </Form>
-        </CardBody>
-      </Card>
-    </PageSection>
+                    <TextListItem component={TextListItemVariants.dt}>Last Accessed</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.last_accessed}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Is Organization</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.is_organization.toString()}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Company</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.company}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Creation date</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.creation_date}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Last Accessed on</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.last_accessed}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Invoice Email</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.invoice_email}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Private Repositories count</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.private_repo_count}</TextListItem>
+
+                    <TextListItem component={TextListItemVariants.dt}>Public Repositories count</TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>{response.public_repo_count}</TextListItem>
+                  </TextList>
+                </TextContent>) : null
+              }
+
+              <ActionGroup>
+                <Button variant="primary" onClick={fetchUser}>
+                  Fetch User
+                </Button>
+              </ActionGroup>
+            </Form>
+          </CardBody>
+        </Card>
+      </PageSection>
+      <DisableUser></DisableUser>
+    </div>
   );
 }

--- a/frontend/src/app/SiteUtils/SiteUtils.tsx
+++ b/frontend/src/app/SiteUtils/SiteUtils.tsx
@@ -185,8 +185,10 @@ export const SiteUtils: React.FunctionComponent = (props) => {
     bannerBody = (<div id="no-banners-found-message">No existing banners</div>)
   }
 
+  if (!UserService.hasRealmRole(ADMIN_ROLE)) {
+    return null;
+  }
   return (
-    ( UserService.hasRealmRole(ADMIN_ROLE) ?
     <PageSection>
       <Modal
           isOpen={isModalOpen}
@@ -269,6 +271,6 @@ export const SiteUtils: React.FunctionComponent = (props) => {
         >
           Are you sure you want to delete this banner?
         </Modal>}
-    </PageSection> : null)
+    </PageSection>
   )
 }

--- a/frontend/src/app/SiteUtils/SiteUtils.tsx
+++ b/frontend/src/app/SiteUtils/SiteUtils.tsx
@@ -20,7 +20,8 @@ import {
 } from '@patternfly/react-core';
 import ReactMarkdown from 'react-markdown';
 import { useState, useEffect } from 'react';
-import HttpService from "../../services/HttpService";
+import HttpService from "src/services/HttpService";
+import UserService from "src/services/UserService";
 
 type FormSelectEntry = {
   value: string,
@@ -46,6 +47,8 @@ const availableSeverityLevels: FormSelectEntry[] = [
   { value: "danger", label: "danger" },
 ]
 
+const ADMIN_ROLE = window.ADMIN_ROLE || process.env.ADMIN_ROLE;
+
 export const SiteUtils: React.FunctionComponent = (props) => {
 
   const [banners, setBanners] = useState<banner[]>([]);
@@ -59,7 +62,9 @@ export const SiteUtils: React.FunctionComponent = (props) => {
   const [bannerLoadFailure, setBannerLoadFailure] = useState(false);
 
   useEffect(() => {
-    loadBanners()
+    if (UserService.hasRealmRole(ADMIN_ROLE)) {
+      loadBanners();
+    }
   }, []);
 
   function resetBannerInput() {
@@ -181,6 +186,7 @@ export const SiteUtils: React.FunctionComponent = (props) => {
   }
 
   return (
+    ( UserService.hasRealmRole(ADMIN_ROLE) ?
     <PageSection>
       <Modal
           isOpen={isModalOpen}
@@ -263,6 +269,6 @@ export const SiteUtils: React.FunctionComponent = (props) => {
         >
           Are you sure you want to delete this banner?
         </Modal>}
-    </PageSection>
+    </PageSection> : null)
   )
 }

--- a/frontend/src/app/UserUtils/UserUtils.tsx
+++ b/frontend/src/app/UserUtils/UserUtils.tsx
@@ -147,7 +147,6 @@ export const UserUtils : React.FunctionComponent = (props: Props) => {
       <EnableUser></EnableUser>
       <DeleteUser></DeleteUser>
       <FetchUserFromEmail></FetchUserFromEmail>
-
       <FetchUserFromName></FetchUserFromName>
     </div>
   );

--- a/frontend/src/app/UserUtils/UserUtils.tsx
+++ b/frontend/src/app/UserUtils/UserUtils.tsx
@@ -17,6 +17,8 @@ import HttpService from "../../services/HttpService";
 import { DisableUser } from './actions/DisableUser';
 import { EnableUser } from './actions/EnableUser';
 import { DeleteUser } from './actions/DeleteUser';
+import {FetchUserFromEmail} from "./actions/FetchUserFromEmail";
+import {FetchUserFromName}  from "./actions/FetchUserFromName";
 
 type Props = {
 
@@ -146,6 +148,8 @@ export const UserUtils : React.FunctionComponent = (props: Props) => {
       <DisableUser></DisableUser>
       <EnableUser></EnableUser>
       <DeleteUser></DeleteUser>
+      <FetchUserFromEmail></FetchUserFromEmail>
+      <FetchUserFromName></FetchUserFromName>
     </div>
   );
 };

--- a/frontend/src/app/UserUtils/UserUtils.tsx
+++ b/frontend/src/app/UserUtils/UserUtils.tsx
@@ -14,7 +14,6 @@ import {
 } from '@patternfly/react-core';
 import { useState } from 'react';
 import HttpService from "../../services/HttpService";
-import { DisableUser } from './actions/DisableUser';
 import { EnableUser } from './actions/EnableUser';
 import { DeleteUser } from './actions/DeleteUser';
 import {FetchUserFromEmail} from "./actions/FetchUserFromEmail";
@@ -145,10 +144,10 @@ export const UserUtils : React.FunctionComponent = (props: Props) => {
           </CardBody>
         </Card>
       </PageSection> */}
-      <DisableUser></DisableUser>
       <EnableUser></EnableUser>
       <DeleteUser></DeleteUser>
       <FetchUserFromEmail></FetchUserFromEmail>
+
       <FetchUserFromName></FetchUserFromName>
     </div>
   );

--- a/frontend/src/app/UserUtils/actions/FetchUserFromEmail.tsx
+++ b/frontend/src/app/UserUtils/actions/FetchUserFromEmail.tsx
@@ -69,19 +69,37 @@ export const FetchUserFromEmail: React.FunctionComponent = (props) => {
               <TextContent>
                 <TextList component={TextListVariants.dl}>
                   <TextListItem component={TextListItemVariants.dt}>Quay.io User name</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.username}
-                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.username}</TextListItem>
 
                   <TextListItem component={TextListItemVariants.dt}>Enabled</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.enabled ? 'True' : 'False'}
-                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.enabled.toString()}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Is Paid User</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.paid_user.toString()}</TextListItem>
 
                   <TextListItem component={TextListItemVariants.dt}>Last Accessed</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.last_accessed}
-                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.last_accessed}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Is Organization</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.is_organization.toString()}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Company</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.company}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Creation date</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.creation_date}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Last Accessed on</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.last_accessed}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Invoice Email</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.invoice_email}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Private Repositories count</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.private_repo_count}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Public Repositories count</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.public_repo_count}</TextListItem>
                 </TextList>
               </TextContent>) : null
             }

--- a/frontend/src/app/UserUtils/actions/FetchUserFromEmail.tsx
+++ b/frontend/src/app/UserUtils/actions/FetchUserFromEmail.tsx
@@ -13,7 +13,7 @@ export const FetchUserFromEmail: React.FunctionComponent = (props) => {
   const [userEmail, setUserEmail] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [message, setMessage] = useState('');
-  const [response, setResponse] = useState(false);
+  const [response, setResponse] = useState('');
 
   const userEmailOnChange = (value) => {
     setUserEmail(value);

--- a/frontend/src/app/UserUtils/actions/FetchUserFromEmail.tsx
+++ b/frontend/src/app/UserUtils/actions/FetchUserFromEmail.tsx
@@ -9,22 +9,22 @@ import {
 import {useState} from "react";
 import HttpService from "src/services/HttpService";
 
-export const ExportCompliance: React.FunctionComponent = (props) => {
-  const [userName, setUserName] = useState('');
+export const FetchUserFromEmail: React.FunctionComponent = (props) => {
+  const [userEmail, setUserEmail] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [message, setMessage] = useState('');
   const [response, setResponse] = useState(false);
 
-  const userNameOnChange = (value) => {
-    setUserName(value);
+  const userEmailOnChange = (value) => {
+    setUserEmail(value);
     if (value == '') {
       setResponse('');
     }
   }
 
   async function fetchUser() {
-    if (userName != '') {
-       HttpService.axiosClient.get(`/federateduser/${userName}`)
+    if (userEmail != '') {
+       HttpService.axiosClient.get(`/quayuseremail/${userEmail}`)
       .then(function (response) {
         setResponse(response.data);
       })
@@ -50,25 +50,25 @@ export const ExportCompliance: React.FunctionComponent = (props) => {
         <span>{message}</span>
       </Modal>
       <Card>
-        <CardTitle className={'text-uppercase'}> Fetch User details </CardTitle>
+        <CardTitle className={'text-uppercase'}> Fetch User details from users Quay.io Email </CardTitle>
         <CardBody>
           <Form>
-            <FormGroup label="User name" fieldId="user-name" isRequired>
+            <FormGroup label="User email" fieldId="user-email" isRequired>
               <TextInput
                 isRequired
                 type="text"
-                id="user-name"
-                name="user-name"
-                value={userName}
-                onChange={(value) => userNameOnChange(value)}
-                placeholder="User name"
+                id="user-email"
+                name="user-email"
+                value={userEmail}
+                onChange={(value) => userEmailOnChange(value)}
+                placeholder="User email"
               />
             </FormGroup>
 
             { response ? (
               <TextContent>
                 <TextList component={TextListVariants.dl}>
-                  <TextListItem component={TextListItemVariants.dt}>Quay.io Username</TextListItem>
+                  <TextListItem component={TextListItemVariants.dt}>Quay.io User name</TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
                     {response.username}
                   </TextListItem>

--- a/frontend/src/app/UserUtils/actions/FetchUserFromName.tsx
+++ b/frontend/src/app/UserUtils/actions/FetchUserFromName.tsx
@@ -9,7 +9,7 @@ import {
 import {useState} from "react";
 import HttpService from "src/services/HttpService";
 
-export const ExportCompliance: React.FunctionComponent = (props) => {
+export const FetchUserFromName: React.FunctionComponent = (props) => {
   const [userName, setUserName] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [message, setMessage] = useState('');
@@ -24,7 +24,7 @@ export const ExportCompliance: React.FunctionComponent = (props) => {
 
   async function fetchUser() {
     if (userName != '') {
-       HttpService.axiosClient.get(`/federateduser/${userName}`)
+       HttpService.axiosClient.get(`/quayusername/${userName}`)
       .then(function (response) {
         setResponse(response.data);
       })
@@ -50,7 +50,7 @@ export const ExportCompliance: React.FunctionComponent = (props) => {
         <span>{message}</span>
       </Modal>
       <Card>
-        <CardTitle className={'text-uppercase'}> Fetch User details </CardTitle>
+        <CardTitle className={'text-uppercase'}> Fetch User details from users Quay.io Username </CardTitle>
         <CardBody>
           <Form>
             <FormGroup label="User name" fieldId="user-name" isRequired>
@@ -68,9 +68,9 @@ export const ExportCompliance: React.FunctionComponent = (props) => {
             { response ? (
               <TextContent>
                 <TextList component={TextListVariants.dl}>
-                  <TextListItem component={TextListItemVariants.dt}>Quay.io Username</TextListItem>
+                  <TextListItem component={TextListItemVariants.dt}>User email</TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
-                    {response.username}
+                    {response.email}
                   </TextListItem>
 
                   <TextListItem component={TextListItemVariants.dt}>Enabled</TextListItem>

--- a/frontend/src/app/UserUtils/actions/FetchUserFromName.tsx
+++ b/frontend/src/app/UserUtils/actions/FetchUserFromName.tsx
@@ -69,19 +69,37 @@ export const FetchUserFromName: React.FunctionComponent = (props) => {
               <TextContent>
                 <TextList component={TextListVariants.dl}>
                   <TextListItem component={TextListItemVariants.dt}>User email</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.email}
-                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.email}</TextListItem>
 
                   <TextListItem component={TextListItemVariants.dt}>Enabled</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.enabled ? 'True' : 'False'}
-                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.enabled.toString()}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Is Paid User</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.paid_user.toString()}</TextListItem>
 
                   <TextListItem component={TextListItemVariants.dt}>Last Accessed</TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>
-                    {response.last_accessed}
-                  </TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.last_accessed}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Is Organization</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.is_organization.toString()}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Company</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.company}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Creation date</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.creation_date}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Last Accessed on</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.last_accessed}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Invoice Email</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.invoice_email}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Private Repositories count</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.private_repo_count}</TextListItem>
+
+                  <TextListItem component={TextListItemVariants.dt}>Public Repositories count</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>{response.public_repo_count}</TextListItem>
                 </TextList>
               </TextContent>) : null
             }

--- a/frontend/src/app/UserUtils/actions/FetchUserFromName.tsx
+++ b/frontend/src/app/UserUtils/actions/FetchUserFromName.tsx
@@ -13,7 +13,7 @@ export const FetchUserFromName: React.FunctionComponent = (props) => {
   const [userName, setUserName] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [message, setMessage] = useState('');
-  const [response, setResponse] = useState(false);
+  const [response, setResponse] = useState('');
 
   const userNameOnChange = (value) => {
     setUserName(value);
@@ -29,7 +29,7 @@ export const FetchUserFromName: React.FunctionComponent = (props) => {
         setResponse(response.data);
       })
       .catch(function (error) {
-        setMessage(error.response.data.message);
+        error.response ? setMessage(error?.response?.data?.message) : setMessage(error);
         setIsModalOpen(true);
       });
     }

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -5,8 +5,6 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
 import { AppRoutes } from '@app/routes';
 import '@app/app.css';
-import HttpService from "../services/HttpService";
-import UserService from "../services/UserService";
 
 const App: React.FunctionComponent = (props) => {
 

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -3,6 +3,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { SiteUtils } from '@app/SiteUtils/SiteUtils';
 import { UserUtils } from '@app/UserUtils/UserUtils';
+import { ExportCompliance } from '@app/ExportCompliance/ExportCompliance';
 import { GeneralSettings } from '@app/Settings/General/GeneralSettings';
 import { ProfileSettings } from '@app/Settings/Profile/ProfileSettings';
 import { NotFound } from '@app/NotFound/NotFound';
@@ -33,7 +34,7 @@ const routes: AppRouteConfig[] = [
   {
     component: SiteUtils,
     exact: true,
-    label: 'Site Uitls',
+    label: 'Site Utils',
     path: '/',
     title: 'Quay Service Tool | Site Utils',
   },
@@ -43,7 +44,15 @@ const routes: AppRouteConfig[] = [
     isAsync: true,
     label: 'User Utils',
     path: '/user',
-    title: 'Quay Service Tool| User Utils',
+    title: 'Quay Service Tool | User Utils',
+  },
+  {
+    component: ExportCompliance,
+    exact: true,
+    isAsync: true,
+    label: 'Export Compliance',
+    path: '/export-compliance',
+    title: 'Quay Service Tool | Export Compliance',
   },
   {
     label: 'Settings',

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
+import UserService from "src/services/UserService";
 import { SiteUtils } from '@app/SiteUtils/SiteUtils';
 import { UserUtils } from '@app/UserUtils/UserUtils';
 import { ExportCompliance } from '@app/ExportCompliance/ExportCompliance';
@@ -21,6 +22,7 @@ export interface IAppRoute {
   title: string;
   isAsync?: boolean;
   routes?: undefined;
+  permission?: string;
 }
 
 export interface IAppRouteGroup {
@@ -30,6 +32,9 @@ export interface IAppRouteGroup {
 
 export type AppRouteConfig = IAppRoute | IAppRouteGroup;
 
+const AdminPerms = process.env.ADMIN_ROLE || window.ADMIN_ROLE;
+const ExportPerms = process.env.EXPORT_COMPLIANCE_ROLE || window.EXPORT_COMPLIANCE_ROLE;
+
 const routes: AppRouteConfig[] = [
   {
     component: SiteUtils,
@@ -37,6 +42,7 @@ const routes: AppRouteConfig[] = [
     label: 'Site Utils',
     path: '/',
     title: 'Quay Service Tool | Site Utils',
+    permission: AdminPerms,
   },
   {
     component: UserUtils,
@@ -45,6 +51,7 @@ const routes: AppRouteConfig[] = [
     label: 'User Utils',
     path: '/user',
     title: 'Quay Service Tool | User Utils',
+    permission: AdminPerms,
   },
   {
     component: ExportCompliance,
@@ -53,6 +60,7 @@ const routes: AppRouteConfig[] = [
     label: 'Export Compliance',
     path: '/export-compliance',
     title: 'Quay Service Tool | Export Compliance',
+    permission: ExportPerms
   },
   {
     label: 'Settings',

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -21,7 +21,12 @@ if (process.env.NODE_ENV !== "production") {
 
 const renderApp = () => ReactDOM.render(<App />, document.getElementById("root") as HTMLElement);
 if (process.env.NODE_ENV !== "production") {
-  renderApp();
+  if (process.env.TEST_LOCAL_AUTH) {
+    // Testing auth on dev env
+    UserService.initKeycloak(renderApp);
+  } else {
+    renderApp();
+  }
 }
 else {
   UserService.initKeycloak(renderApp);

--- a/frontend/src/services/HttpService.tsx
+++ b/frontend/src/services/HttpService.tsx
@@ -11,10 +11,10 @@ const _axios = axios.create();
 
 const configure = () => {
   _axios.interceptors.request.use((config) => {
-    if (process.env.NODE_ENV !== "production") {
+    if (process.env.NODE_ENV !== "production" && !process.env.TEST_LOCAL_AUTH) {
       return config;
     }
-    else if (UserService.isLoggedIn()) {
+    if (UserService.isLoggedIn()) {
       const cb = () => {
         config.headers.Authorization = `Bearer ${UserService.getToken()}`;
         return Promise.resolve(config);

--- a/frontend/src/services/UserService.tsx
+++ b/frontend/src/services/UserService.tsx
@@ -41,9 +41,10 @@ const updateToken = (successCallback) =>
 
 const username = () => KeycloakInstance.tokenParsed?.preferred_username;
 
-const hasRole = (roles) => roles.some((role) => KeycloakInstance.hasRealmRole(role));
+const hasRealmRole = (role) => KeycloakInstance.hasRealmRole(role);
 
 const UserService = {
+  Keycloak,
   initKeycloak,
   login,
   logout,
@@ -52,7 +53,7 @@ const UserService = {
   email,
   updateToken,
   username,
-  hasRole,
+  hasRealmRole
 };
 
 export default UserService;

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -21,7 +21,7 @@ module.exports = merge(common('development'), {
     proxy: [
       {
         context: ["/auth**"],
-        target: process.env.AUTH_URL || "http://0.0.0.0:8081",
+        target: process.env.AUTH_URL || "http://localhost:8081",
         secure: false,
         changeOrigin: false
       },


### PR DESCRIPTION
This PR:
1. Adds role checks and displays various components accordingly. There are `ADMIN_ROLE` and `EXPORT_COMPLIANCE_ROLE` defined in the config.yaml
2. Adds a new tab `Export Compliance` that fetches quay user data from the supplied Red Hat SSO username.
3. Adds a new permission check decorator for all backend endpoints.

Users with only export compliance role see the export compliance tab. The export compliance tab has an option to fetch  quay user data from the supplied Red Hat SSO username and clean build queue & disable the user.
<img width="961" alt="Screen Shot 2022-10-05 at 12 44 36 PM" src="https://user-images.githubusercontent.com/11522230/194116232-55df3946-fa88-41a6-a99e-26cffe8c9c23.png">
<img width="1918" alt="Screen Shot 2022-10-05 at 12 44 52 PM" src="https://user-images.githubusercontent.com/11522230/194116293-802b1065-f75b-4595-8267-0a58699dba45.png">


Users with admin and export compliance role see all the tabs of the tool:
<img width="1916" alt="Screen Shot 2022-10-05 at 12 48 50 PM" src="https://user-images.githubusercontent.com/11522230/194116609-cb54f6c3-6396-42d8-a583-7adee427bcd9.png">
