### PR TITLE
add account numbers to FetchUser tasks

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,6 +15,7 @@ from tasks.user import UserTask, FetchUserFromEmailTask, FetchUserFromNameTask, 
 import yaml
 import logging
 from utils import *
+from util.marketplace import MarketplaceUserApi
 from data import database
 import os
 
@@ -74,6 +75,8 @@ conn_args["autorollback"] = True
 app.config["DB_CONNECTION_ARGS"] = conn_args
 app.config["DB_TRANSACTION_FACTORY"] = create_transaction
 database.configure(app.config)
+
+marketplace_users = MarketplaceUserApi(app)
 
 
 @app.route("/healthcheck")

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -28,5 +28,13 @@ authentication:
     - openshift-logging
     - openshift-pipeline
     - openshiftio
+# Red Hat Marketplace API configuration
+# In production, set FEATURE_RH_MARKETPLACE to true and provide the
+# API endpoints. The service tool must also have access to the same
+# marketplace certs as quay (/conf/stack/quay-marketplace-api.crt/.key).
+FEATURE_RH_MARKETPLACE: false
+ENTITLEMENT_RECONCILIATION_USER_ENDPOINT: ""
+ENTITLEMENT_RECONCILIATION_MARKETPLACE_ENDPOINT: ""
+
 ENV: development
 DEBUG: true

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -1,10 +1,10 @@
 from flask_restful import Resource, reqparse, inputs
 from flask_login import login_required
-from flask import make_response
+from flask import make_response, current_app
 import json
 
 from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm, protect_namespace
-from data.model import user, db_transaction, entitlements
+from data.model import user, db_transaction
 from data.database import (
     Repository,
     RepositoryBuild,
@@ -164,7 +164,8 @@ class FetchUserFromNameTask(Resource):
 
             private_repo_count = user.get_private_repo_count(found_user.username)
             public_repo_count = user.get_public_repo_count(found_user.username)
-            account_numbers = entitlements.get_web_customer_ids(found_user.id)
+            marketplace_users = current_app.extensions.get("marketplace_user_api")
+            account_numbers = marketplace_users.get_account_number(found_user) if marketplace_users else None
 
             return make_response(
                 json.dumps({
@@ -206,7 +207,8 @@ class FetchUserFromEmailTask(Resource):
                 )
             private_repo_count = user.get_private_repo_count(found_user.username)
             public_repo_count = user.get_public_repo_count(found_user.username)
-            account_numbers = entitlements.get_web_customer_ids(found_user.id)
+            marketplace_users = current_app.extensions.get("marketplace_user_api")
+            account_numbers = marketplace_users.get_account_number(found_user) if marketplace_users else None
 
             return make_response(
                 json.dumps({

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -4,7 +4,7 @@ from flask import make_response
 import json
 
 from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm, protect_namespace
-from data.model import user, db_transaction
+from data.model import user, db_transaction, entitlements
 from data.database import (
     Repository,
     RepositoryBuild,
@@ -164,9 +164,11 @@ class FetchUserFromNameTask(Resource):
 
             private_repo_count = user.get_private_repo_count(found_user.username)
             public_repo_count = user.get_public_repo_count(found_user.username)
+            account_numbers = entitlements.get_web_customer_ids(found_user.id)
 
             return make_response(
                 json.dumps({
+                    "account_numbers": account_numbers,
                     "email": found_user.email,
                     "enabled": found_user.enabled,
                     "paid_user": True if found_user.stripe_id else False,
@@ -204,9 +206,11 @@ class FetchUserFromEmailTask(Resource):
                 )
             private_repo_count = user.get_private_repo_count(found_user.username)
             public_repo_count = user.get_public_repo_count(found_user.username)
+            account_numbers = entitlements.get_web_customer_ids(found_user.id)
 
             return make_response(
                 json.dumps({
+                    "account_numbers": account_numbers,
                     "username": found_user.username,
                     "enabled": found_user.enabled,
                     "paid_user": True if found_user.stripe_id else False,
@@ -215,7 +219,7 @@ class FetchUserFromEmailTask(Resource):
                     "company": found_user.company,
                     "creation_date": str(found_user.creation_date),
                     "invoice_email": found_user.invoice_email_address,
-                    "stripe_id": found_user.stripe_id,                    
+                    "stripe_id": found_user.stripe_id,
                     "private_repo_count": private_repo_count,
                     "public_repo_count": public_repo_count,
                 }),

--- a/backend/tests/tasks/test_user.py
+++ b/backend/tests/tasks/test_user.py
@@ -112,20 +112,23 @@ class TestUserPut:
 
 class TestFetchUserFromName:
 
-    @patch('tasks.user.entitlements')
     @patch('tasks.user.user')
-    def test_returns_user_with_account_numbers(self, mock_user, mock_entitlements, client):
-        mock_user.get_namespace_user.return_value = make_mock_user()
+    def test_returns_user_with_account_numbers(self, mock_user, client):
+        mock_found_user = make_mock_user()
+        mock_user.get_namespace_user.return_value = mock_found_user
         mock_user.get_private_repo_count.return_value = 5
         mock_user.get_public_repo_count.return_value = 10
-        mock_entitlements.get_web_customer_ids.return_value = [12345, 67890]
+
+        mock_marketplace = Mock()
+        mock_marketplace.get_account_number.return_value = [12345, 67890]
+        app.extensions['marketplace_user_api'] = mock_marketplace
 
         res = client.get('/quayusername/test')
         data = json.loads(res.data)
 
         assert res.status_code == 200
         assert data['account_numbers'] == [12345, 67890]
-        mock_entitlements.get_web_customer_ids.assert_called_once_with(1)
+        mock_marketplace.get_account_number.assert_called_once_with(mock_found_user)
 
     @patch('tasks.user.user')
     def test_user_not_found(self, mock_user, client):
@@ -133,13 +136,15 @@ class TestFetchUserFromName:
         res = client.get('/quayusername/nonexistent')
         assert res.status_code == 404
 
-    @patch('tasks.user.entitlements')
     @patch('tasks.user.user')
-    def test_account_numbers_none(self, mock_user, mock_entitlements, client):
+    def test_account_numbers_none(self, mock_user, client):
         mock_user.get_namespace_user.return_value = make_mock_user()
         mock_user.get_private_repo_count.return_value = 0
         mock_user.get_public_repo_count.return_value = 0
-        mock_entitlements.get_web_customer_ids.return_value = None
+
+        mock_marketplace = Mock()
+        mock_marketplace.get_account_number.return_value = None
+        app.extensions['marketplace_user_api'] = mock_marketplace
 
         res = client.get('/quayusername/test')
         data = json.loads(res.data)
@@ -150,20 +155,23 @@ class TestFetchUserFromName:
 
 class TestFetchUserFromEmail:
 
-    @patch('tasks.user.entitlements')
     @patch('tasks.user.user')
-    def test_returns_user_with_account_numbers(self, mock_user, mock_entitlements, client):
-        mock_user.find_user_by_email.return_value = make_mock_user()
+    def test_returns_user_with_account_numbers(self, mock_user, client):
+        mock_found_user = make_mock_user()
+        mock_user.find_user_by_email.return_value = mock_found_user
         mock_user.get_private_repo_count.return_value = 5
         mock_user.get_public_repo_count.return_value = 10
-        mock_entitlements.get_web_customer_ids.return_value = [67890]
+
+        mock_marketplace = Mock()
+        mock_marketplace.get_account_number.return_value = [67890]
+        app.extensions['marketplace_user_api'] = mock_marketplace
 
         res = client.get('/quayuseremail/test@example.com')
         data = json.loads(res.data)
 
         assert res.status_code == 200
         assert data['account_numbers'] == [67890]
-        mock_entitlements.get_web_customer_ids.assert_called_once_with(1)
+        mock_marketplace.get_account_number.assert_called_once_with(mock_found_user)
 
     @patch('tasks.user.user')
     def test_user_not_found(self, mock_user, client):
@@ -171,13 +179,15 @@ class TestFetchUserFromEmail:
         res = client.get('/quayuseremail/missing@example.com')
         assert res.status_code == 404
 
-    @patch('tasks.user.entitlements')
     @patch('tasks.user.user')
-    def test_account_numbers_none(self, mock_user, mock_entitlements, client):
+    def test_account_numbers_none(self, mock_user, client):
         mock_user.find_user_by_email.return_value = make_mock_user()
         mock_user.get_private_repo_count.return_value = 0
         mock_user.get_public_repo_count.return_value = 0
-        mock_entitlements.get_web_customer_ids.return_value = None
+
+        mock_marketplace = Mock()
+        mock_marketplace.get_account_number.return_value = None
+        app.extensions['marketplace_user_api'] = mock_marketplace
 
         res = client.get('/quayuseremail/test@example.com')
         data = json.loads(res.data)

--- a/backend/tests/tasks/test_user.py
+++ b/backend/tests/tasks/test_user.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch, call, PropertyMock
 from app import app
+import json
 import pytest as pytest
 
 @pytest.fixture
@@ -11,6 +12,16 @@ def get_mock_context():
     mock_context.__enter__ = Mock(return_value=(Mock(), None))
     mock_context.__exit__ = Mock(return_value=None)
     return mock_context
+
+def make_mock_user(**overrides):
+    defaults = dict(
+        id=1, username='test', email='test@example.com', enabled=True,
+        stripe_id='cus_123', last_accessed='2024-01-01', organization=False,
+        company='TestCo', creation_date='2023-01-01',
+        invoice_email_address='billing@example.com',
+    )
+    defaults.update(overrides)
+    return Mock(**defaults)
 
 class TestUserGet:
 
@@ -97,3 +108,79 @@ class TestUserPut:
         res = client.put('/user/test?enable=false')
         assert res.status_code == 400
         assert res.data == b'{"message": "User test already disabled"}'
+
+
+class TestFetchUserFromName:
+
+    @patch('tasks.user.entitlements')
+    @patch('tasks.user.user')
+    def test_returns_user_with_account_numbers(self, mock_user, mock_entitlements, client):
+        mock_user.get_namespace_user.return_value = make_mock_user()
+        mock_user.get_private_repo_count.return_value = 5
+        mock_user.get_public_repo_count.return_value = 10
+        mock_entitlements.get_web_customer_ids.return_value = [12345, 67890]
+
+        res = client.get('/quayusername/test')
+        data = json.loads(res.data)
+
+        assert res.status_code == 200
+        assert data['account_numbers'] == [12345, 67890]
+        mock_entitlements.get_web_customer_ids.assert_called_once_with(1)
+
+    @patch('tasks.user.user')
+    def test_user_not_found(self, mock_user, client):
+        mock_user.get_namespace_user.return_value = None
+        res = client.get('/quayusername/nonexistent')
+        assert res.status_code == 404
+
+    @patch('tasks.user.entitlements')
+    @patch('tasks.user.user')
+    def test_account_numbers_none(self, mock_user, mock_entitlements, client):
+        mock_user.get_namespace_user.return_value = make_mock_user()
+        mock_user.get_private_repo_count.return_value = 0
+        mock_user.get_public_repo_count.return_value = 0
+        mock_entitlements.get_web_customer_ids.return_value = None
+
+        res = client.get('/quayusername/test')
+        data = json.loads(res.data)
+
+        assert res.status_code == 200
+        assert data['account_numbers'] is None
+
+
+class TestFetchUserFromEmail:
+
+    @patch('tasks.user.entitlements')
+    @patch('tasks.user.user')
+    def test_returns_user_with_account_numbers(self, mock_user, mock_entitlements, client):
+        mock_user.find_user_by_email.return_value = make_mock_user()
+        mock_user.get_private_repo_count.return_value = 5
+        mock_user.get_public_repo_count.return_value = 10
+        mock_entitlements.get_web_customer_ids.return_value = [67890]
+
+        res = client.get('/quayuseremail/test@example.com')
+        data = json.loads(res.data)
+
+        assert res.status_code == 200
+        assert data['account_numbers'] == [67890]
+        mock_entitlements.get_web_customer_ids.assert_called_once_with(1)
+
+    @patch('tasks.user.user')
+    def test_user_not_found(self, mock_user, client):
+        mock_user.find_user_by_email.return_value = None
+        res = client.get('/quayuseremail/missing@example.com')
+        assert res.status_code == 404
+
+    @patch('tasks.user.entitlements')
+    @patch('tasks.user.user')
+    def test_account_numbers_none(self, mock_user, mock_entitlements, client):
+        mock_user.find_user_by_email.return_value = make_mock_user()
+        mock_user.get_private_repo_count.return_value = 0
+        mock_user.get_public_repo_count.return_value = 0
+        mock_entitlements.get_web_customer_ids.return_value = None
+
+        res = client.get('/quayuseremail/test@example.com')
+        data = json.loads(res.data)
+
+        assert res.status_code == 200
+        assert data['account_numbers'] is None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - ./backend/templates:/backend/templates
       - ./backend/config:/backend/config
       - ./backend/tests:/backend/tests
+      # Mount marketplace certs from quay's conf/stack if available
+      # - ./conf/stack/quay-marketplace-api.crt:/conf/stack/quay-marketplace-api.crt:ro
+      # - ./conf/stack/quay-marketplace-api.key:/conf/stack/quay-marketplace-api.key:ro
     ports:
       - '5000:5000'
     environment:

--- a/frontend/e2e/account-numbers.spec.ts
+++ b/frontend/e2e/account-numbers.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
 
+// These tests require a live backend + database (not available in CI)
+test.skip(() => !process.env.TARGET_URL, "Skipped: no backend (set TARGET_URL)");
+
 test.describe("Account numbers in FetchUser", () => {
   test("displays account numbers when fetching user by username", async ({
     page,

--- a/frontend/e2e/account-numbers.spec.ts
+++ b/frontend/e2e/account-numbers.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Account numbers in FetchUser", () => {
+  test("displays account numbers when fetching user by username", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "User Utils" }).click();
+    await expect(page).toHaveURL(/\/user/);
+
+    // Scope to the Username card
+    const usernameCard = page
+      .locator("article")
+      .filter({ hasText: "Fetch User details from users Quay.io Username" });
+
+    await usernameCard.locator("input#user-name").fill("testuser");
+    await usernameCard.getByRole("button", { name: "Fetch User" }).click();
+
+    // Verify account numbers appear in the response
+    await expect(usernameCard.getByText("Account numbers")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(usernameCard.getByText("6543210, 9876543")).toBeVisible();
+
+    // Verify other user info fields are present
+    await expect(usernameCard.getByText("TestCorp", { exact: true })).toBeVisible();
+    await expect(usernameCard.getByText("cus_test123")).toBeVisible();
+  });
+
+  test("displays account numbers when fetching user by email", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "User Utils" }).click();
+    await expect(page).toHaveURL(/\/user/);
+
+    // Scope to the Email card
+    const emailCard = page
+      .locator("article")
+      .filter({ hasText: "Fetch User details from users Quay.io Email" });
+
+    await emailCard.locator("input#user-email").fill("testuser@example.com");
+    await emailCard.getByRole("button", { name: "Fetch User" }).click();
+
+    // Verify account numbers appear
+    await expect(emailCard.getByText("Account numbers")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(emailCard.getByText("6543210, 9876543")).toBeVisible();
+
+    // Verify username is shown
+    await expect(emailCard.getByText("testuser")).toBeVisible();
+  });
+
+  test("shows error for non-existent user", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "User Utils" }).click();
+
+    const usernameCard = page
+      .locator("article")
+      .filter({ hasText: "Fetch User details from users Quay.io Username" });
+
+    await usernameCard.locator("input#user-name").fill("nonexistent_user");
+    await usernameCard.getByRole("button", { name: "Fetch User" }).click();
+
+    // Error modal appears at page level
+    await expect(
+      page.getByText("Could not find user nonexistent_user")
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/e2e/account-numbers.spec.ts
+++ b/frontend/e2e/account-numbers.spec.ts
@@ -16,18 +16,14 @@ test.describe("Account numbers in FetchUser", () => {
       .locator("article")
       .filter({ hasText: "Fetch User details from users Quay.io Username" });
 
-    await usernameCard.locator("input#user-name").fill("testuser");
+    await usernameCard.locator("input#user-name").fill("subscription");
     await usernameCard.getByRole("button", { name: "Fetch User" }).click();
 
-    // Verify account numbers appear in the response
+    // Verify account numbers from marketplace API (FakeUserApi returns [12345])
     await expect(usernameCard.getByText("Account numbers")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(usernameCard.getByText("6543210, 9876543")).toBeVisible();
-
-    // Verify other user info fields are present
-    await expect(usernameCard.getByText("TestCorp", { exact: true })).toBeVisible();
-    await expect(usernameCard.getByText("cus_test123")).toBeVisible();
+    await expect(usernameCard.getByText("12345")).toBeVisible();
   });
 
   test("displays account numbers when fetching user by email", async ({
@@ -42,17 +38,16 @@ test.describe("Account numbers in FetchUser", () => {
       .locator("article")
       .filter({ hasText: "Fetch User details from users Quay.io Email" });
 
-    await emailCard.locator("input#user-email").fill("testuser@example.com");
+    await emailCard
+      .locator("input#user-email")
+      .fill("subscriptions@devtable.com");
     await emailCard.getByRole("button", { name: "Fetch User" }).click();
 
-    // Verify account numbers appear
+    // Verify account numbers from marketplace API
     await expect(emailCard.getByText("Account numbers")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(emailCard.getByText("6543210, 9876543")).toBeVisible();
-
-    // Verify username is shown
-    await expect(emailCard.getByText("testuser")).toBeVisible();
+    await expect(emailCard.getByText("12345")).toBeVisible();
   });
 
   test("shows error for non-existent user", async ({ page }) => {

--- a/frontend/src/app/common/UserInfo.tsx
+++ b/frontend/src/app/common/UserInfo.tsx
@@ -9,6 +9,9 @@ export const UserInfo = (props: UserInfoProps): React.ReactElement => {
 
   return (<TextContent>
     <TextList component={TextListVariants.dl}>
+      <TextListItem component={TextListItemVariants.dt}>Account numbers</TextListItem>
+      <TextListItem component={TextListItemVariants.dd}>{userinfo.account_numbers ? userinfo.account_numbers.join(', ') : 'N/A'}</TextListItem>
+
       <TextListItem component={TextListItemVariants.dt}>Quay.io User name</TextListItem>
       <TextListItem component={TextListItemVariants.dd}>{userinfo.username}</TextListItem>
 


### PR DESCRIPTION
Adds the EBS account number for user to the information provided when fetching user info by username or email.


https://github.com/user-attachments/assets/8b8364f7-9b69-461b-ad95-b5ffdb3d7aa2

