### PR TITLE
Fix: Dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ flask-restful==0.3.10
 Flask-Login==0.6.3
 python-keycloak==0.24
 prometheus-client==0.13.1
-prometheus-flask-exporter==0.18.7
+prometheus-flask-exporter==0.23.2
 text_unidecode==1.3
 psycopg2-binary==2.9.1
 # service tool & cloudwatch log process are started through supervisor

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,16 +1,17 @@
-git+https://github.com/quay/quay@bf82e26c56416ec3d0a812c051baa60ccdc76bea#egg=quay
-markupsafe==2.1.3
-itsdangerous==2.1.2
+git+https://github.com/quay/quay@57915a5ef3b0065d878f51fae3bae892f9c019e9#egg=quay
+markupsafe==3.0.2
+itsdangerous==2.2.0
 flask-restful==0.3.10
 Flask-Login==0.6.3
-python-keycloak==0.24
-prometheus-client==0.13.1
+python-keycloak==5.8.1
+prometheus-client==0.22.1
 prometheus-flask-exporter==0.23.2
 text_unidecode==1.3
-psycopg2-binary==2.9.1
+psycopg2-binary==2.9.10
 # service tool & cloudwatch log process are started through supervisor
-supervisor==4.2.5
+supervisor==4.3.0
 supervisor-logging==0.0.9
 supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380
-PyMySQL==1.1.1
+PyMySQL==1.1.2
 redis-py-cluster==2.1.3
+resumablesha256==1.0


### PR DESCRIPTION
The current code is throwing this error: 
```
Traceback (most recent call last):
  File "/backend/app.py", line 5, in <module>
    from prometheus_flask_exporter import PrometheusMetrics
  File "/usr/local/lib/python3.9/site-packages/prometheus_flask_exporter/__init__.py", line 12, in <module>
    from flask.views import MethodViewType
ImportError: cannot import name 'MethodViewType' from 'flask.views' (/usr/local/lib/python3.9/site-packages/flask/views.py)
```

The reason is that `prometheus_flask_exporter` is too old for the Flask version installed by quay egg. 

This MR updates all the dependencies in the requirements file. 
