### PR TITLE
refactor: more local dev fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV PATH="$SERVICETOOLDIR/.venv/bin:$PATH"
 
 FROM backend-base AS backend-dev
 EXPOSE 5000
-ENTRYPOINT ["gunicorn", "-k", "gevent", "-b", "0.0.0.0:5000", "--limit-request-field_size", "16384", "app:app"]
+ENTRYPOINT ["gunicorn", "-k", "gevent", "-b", "0.0.0.0:5000", "--limit-request-field_size", "16384", "--reload", "app:app"]
 
 FROM backend-base AS production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,5 +54,5 @@ services:
     env_file:
       - ./frontend/.env
     environment:
-      - NODE_ENV=development
-      - TARGET_URL=http://quay-service-tool-api:5000
+      NODE_ENV: development
+      TARGET_URL: http://quay-service-tool-api:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
     build:
       context: .
       target: backend-dev
-    command: --reload
+    # these are mounted explicitly since mounting all of backend/ will clobber the
+    # virtual environment created by `uv` during the image build
     volumes:
       - ./backend:/backend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,15 @@ services:
     # these are mounted explicitly since mounting all of backend/ will clobber the
     # virtual environment created by `uv` during the image build
     volumes:
-      - ./backend:/backend
+      - ./backend/app.py:/backend/app.py
+      - ./backend/_init.py:/backend/_init.py
+      - ./backend/utils.py:/backend/utils.py
+      - ./backend/tasks:/backend/tasks
+      - ./backend/templates:/backend/templates
+      - ./backend/config:/backend/config
+      - ./backend/tests:/backend/tests
+    ports:
+      - '5000:5000'
     environment:
       ENV: development
       DEBUG: "True"


### PR DESCRIPTION
A few other local dev fixes I missed in https://github.com/quay/quay-service-tool/pull/186

- The virtual environment created during the docker build was getting clobbered by the `./backend` mount so this change explicitly mounts only the source code, not the entire folder onto the container which preserves live reload functionality.
- Moves `--reload` command to the Dockerfile since there is a new target
- Small style fixes