### PR TITLE
feat: permission checks on critical namespaces

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -45,6 +45,8 @@ def load_user_from_request(request):
             (app.config.get('is_local') and app.config.get('test_auth'))):
         try:
             api_key = request.headers.get('Authorization')
+            if not api_key:
+                return User()
             bearer_token = api_key.replace('Bearer ', '', 1)
             keycloak_openid = KeycloakOpenID(
                                             server_url=app.config.get('authentication', {}).get('url'),
@@ -59,7 +61,7 @@ def load_user_from_request(request):
             return Auth.authenticate_user(token_info, app.config.get('authentication'))
         except Exception as e:
             logging.exception(e)
-            return make_response("Error occured while authentication: " + str(e), 500)
+            return User()
     else:
         return User(email="local-dev@testing.com", username="Local Dev", is_authenticated=True)
 

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -15,5 +15,18 @@ authentication:
   roles:
     ADMIN_ROLE: 'admin-role'
     EXPORT_COMPLIANCE_ROLE: 'export-compliance-role'
+    PROTECTED_ADMIN_ROLE: 'protected-admin-role'
+  protected_namespaces:
+    - openshift-release-dev
+    - redhat-prod
+    - redhat
+    - redhat-user-workloads
+    - openshift
+    - redhat-pending
+    - redhat-services-prod
+    - redhat-services-pending
+    - openshift-logging
+    - openshift-pipeline
+    - openshiftio
 ENV: development
 DEBUG: true

--- a/backend/tasks/org_owner.py
+++ b/backend/tasks/org_owner.py
@@ -4,7 +4,7 @@ from flask import make_response
 from flask_login import login_required
 from flask_restful import Resource, reqparse
 
-from utils import log_response, verify_admin_permissions
+from utils import log_response, verify_admin_permissions, check_protected_namespace
 
 from data.model import user, organization, team, InvalidOrganizationException
 from data.model.team import UserAlreadyInTeam
@@ -34,7 +34,10 @@ class AddOrgOwnerTask(Resource):
                 json.dumps({"message": "Parameter 'organization' required"}), 400
             )
 
-        # Look up user
+        protected_response = check_protected_namespace(org_name)
+        if protected_response:
+            return protected_response
+
         found_user = user.get_namespace_user(username)
         if found_user is None:
             return make_response(

--- a/backend/tasks/org_owner.py
+++ b/backend/tasks/org_owner.py
@@ -4,7 +4,7 @@ from flask import make_response
 from flask_login import login_required
 from flask_restful import Resource, reqparse
 
-from utils import log_response, verify_admin_permissions, check_protected_namespace
+from utils import log_response, verify_admin_permissions, protect_namespace
 
 from data.model import user, organization, team, InvalidOrganizationException
 from data.model.team import UserAlreadyInTeam
@@ -14,6 +14,7 @@ from data.database import Team, TeamRole
 class AddOrgOwnerTask(Resource):
     @log_response
     @verify_admin_permissions
+    @protect_namespace("organization")
     @login_required
     def post(self):
         parser = reqparse.RequestParser()
@@ -33,10 +34,6 @@ class AddOrgOwnerTask(Resource):
             return make_response(
                 json.dumps({"message": "Parameter 'organization' required"}), 400
             )
-
-        protected_response = check_protected_namespace(org_name)
-        if protected_response:
-            return protected_response
 
         found_user = user.get_namespace_user(username)
         if found_user is None:

--- a/backend/tasks/robot_token.py
+++ b/backend/tasks/robot_token.py
@@ -5,7 +5,7 @@ from flask import make_response
 from flask_login import login_required
 from flask_restful import Resource, reqparse
 
-from utils import log_response, verify_admin_permissions, check_protected_namespace
+from utils import log_response, verify_admin_permissions, protect_namespace
 
 from data.model import user, organization, InvalidOrganizationException, DataModelException, InvalidRobotException
 
@@ -13,6 +13,7 @@ from data.model import user, organization, InvalidOrganizationException, DataMod
 class RobotTokenTask(Resource):
     @log_response
     @verify_admin_permissions
+    @protect_namespace("organization")
     @login_required
     def post(self):
         parser = reqparse.RequestParser()
@@ -40,10 +41,6 @@ class RobotTokenTask(Resource):
             return make_response(
                 json.dumps({"message": "Parameter 'token' required"}), 400
             )
-
-        protected_response = check_protected_namespace(org)
-        if protected_response:
-            return protected_response
 
         try:
             parent = organization.get_organization(org)

--- a/backend/tasks/robot_token.py
+++ b/backend/tasks/robot_token.py
@@ -5,7 +5,7 @@ from flask import make_response
 from flask_login import login_required
 from flask_restful import Resource, reqparse
 
-from utils import log_response, verify_admin_permissions
+from utils import log_response, verify_admin_permissions, check_protected_namespace
 
 from data.model import user, organization, InvalidOrganizationException, DataModelException, InvalidRobotException
 
@@ -40,6 +40,10 @@ class RobotTokenTask(Resource):
             return make_response(
                 json.dumps({"message": "Parameter 'token' required"}), 400
             )
+
+        protected_response = check_protected_namespace(org)
+        if protected_response:
+            return protected_response
 
         try:
             parent = organization.get_organization(org)

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -3,7 +3,7 @@ from flask_login import login_required
 from flask import make_response
 import json
 
-from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm, check_protected_namespace
+from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm, protect_namespace
 from data.model import user, db_transaction
 from data.database import (
     Repository,
@@ -78,6 +78,7 @@ class UserTask(Resource):
     # Trying to keep this as RESTful as possible, but may want to separate out into it's own 'enable' endpoint
     @log_response
     @verify_admin_or_export_perm
+    @protect_namespace("username")
     @login_required
     def put(self, username):
         # Define params
@@ -91,10 +92,6 @@ class UserTask(Resource):
             return make_response(
                 json.dumps({"message": "Parameter 'enable' required"}), 400
             )
-
-        protected_response = check_protected_namespace(username)
-        if protected_response:
-            return protected_response
 
         try:
             found_user = user.get_namespace_user(username)
@@ -132,12 +129,9 @@ class UserTask(Resource):
 
     @log_response
     @verify_admin_permissions
+    @protect_namespace("username")
     @login_required
     def delete(self, username):
-        protected_response = check_protected_namespace(username)
-        if protected_response:
-            return protected_response
-
         found_user = user.get_namespace_user(username)
         if found_user is None:
             return make_response(
@@ -275,6 +269,7 @@ class FetchUserFromStripeID(Resource):
 class UpdateEmailTask(Resource):
     @log_response
     @verify_admin_permissions
+    @protect_namespace("username")
     @login_required
     def put(self):
         parser = reqparse.RequestParser()
@@ -283,10 +278,6 @@ class UpdateEmailTask(Resource):
         args = parser.parse_args()
         username = args.get("username")
         new_email = args.get("newEmail")
-
-        protected_response = check_protected_namespace(username)
-        if protected_response:
-            return protected_response
 
         try:
             curr_user = user.get_namespace_user(username)

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -3,7 +3,7 @@ from flask_login import login_required
 from flask import make_response
 import json
 
-from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm
+from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm, check_protected_namespace
 from data.model import user, db_transaction
 from data.database import (
     Repository,
@@ -92,6 +92,10 @@ class UserTask(Resource):
                 json.dumps({"message": "Parameter 'enable' required"}), 400
             )
 
+        protected_response = check_protected_namespace(username)
+        if protected_response:
+            return protected_response
+
         try:
             found_user = user.get_namespace_user(username)
             if found_user is None:
@@ -130,6 +134,10 @@ class UserTask(Resource):
     @verify_admin_permissions
     @login_required
     def delete(self, username):
+        protected_response = check_protected_namespace(username)
+        if protected_response:
+            return protected_response
+
         found_user = user.get_namespace_user(username)
         if found_user is None:
             return make_response(
@@ -275,6 +283,10 @@ class UpdateEmailTask(Resource):
         args = parser.parse_args()
         username = args.get("username")
         new_email = args.get("newEmail")
+
+        protected_response = check_protected_namespace(username)
+        if protected_response:
+            return protected_response
 
         try:
             curr_user = user.get_namespace_user(username)

--- a/backend/tasks/username.py
+++ b/backend/tasks/username.py
@@ -4,7 +4,7 @@ from flask import make_response
 from flask_restful import reqparse
 from data import model
 from data.model import InvalidUsernameException, user
-from utils import log_response, verify_admin_permissions
+from utils import log_response, verify_admin_permissions, check_protected_namespace
 import json
 
 
@@ -19,6 +19,10 @@ class UsernameTask(Resource):
         args = parser.parse_args()
         new_user_name = args.get("newUsername")
         current_user_name = args.get("currentUsername")
+
+        protected_response = check_protected_namespace(current_user_name)
+        if protected_response:
+            return protected_response
 
         try:
             curr_user = user.get_namespace_user(current_user_name)

--- a/backend/tasks/username.py
+++ b/backend/tasks/username.py
@@ -4,13 +4,14 @@ from flask import make_response
 from flask_restful import reqparse
 from data import model
 from data.model import InvalidUsernameException, user
-from utils import log_response, verify_admin_permissions, check_protected_namespace
+from utils import log_response, verify_admin_permissions, protect_namespace
 import json
 
 
 class UsernameTask(Resource):
     @log_response
     @verify_admin_permissions
+    @protect_namespace("currentUsername")
     @login_required
     def put(self):
         parser = reqparse.RequestParser()
@@ -19,10 +20,6 @@ class UsernameTask(Resource):
         args = parser.parse_args()
         new_user_name = args.get("newUsername")
         current_user_name = args.get("currentUsername")
-
-        protected_response = check_protected_namespace(current_user_name)
-        if protected_response:
-            return protected_response
 
         try:
             curr_user = user.get_namespace_user(current_user_name)

--- a/backend/tests/test_protected_namespace.py
+++ b/backend/tests/test_protected_namespace.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
+from flask import make_response
 from app import app
-from utils import check_protected_namespace
+from utils import protect_namespace
 import pytest
 import json
 
@@ -49,76 +50,93 @@ def enable_auth():
     app.config['authentication'] = original_auth
 
 
-def mock_user_with_roles(roles):
-    return Mock(
-        is_authenticated=True,
-        email='test@example.com',
-        username='Test User',
-        realm_access={'roles': roles},
-    )
+def _make_protected_fn():
+    @protect_namespace("namespace")
+    def fn(**kwargs):
+        return make_response("ok", 200)
+    return fn
 
 
-class TestCheckProtectedNamespace:
+class TestProtectNamespaceDecorator:
 
     @patch('utils.current_user')
     def test_blocks_protected_namespace_without_role(self, mock_current_user):
         mock_current_user.realm_access = {'roles': ['admin-role']}
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace('redhat-prod')
-        assert result is not None
+            result = fn(namespace='redhat-prod')
         assert result.status_code == 403
         assert b'protected' in result.data.lower()
 
     @patch('utils.current_user')
     def test_allows_protected_namespace_with_role(self, mock_current_user):
         mock_current_user.realm_access = {'roles': ['admin-role', 'protected-admin-role']}
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace('redhat-prod')
-        assert result is None
+            result = fn(namespace='redhat-prod')
+        assert result.status_code == 200
 
     @patch('utils.current_user')
     def test_allows_non_protected_namespace(self, mock_current_user):
         mock_current_user.realm_access = {'roles': ['admin-role']}
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace('some-random-user')
-        assert result is None
+            result = fn(namespace='some-random-user')
+        assert result.status_code == 200
 
     @patch('utils.current_user')
     def test_case_insensitive_match(self, mock_current_user):
         mock_current_user.realm_access = {'roles': ['admin-role']}
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace('RedHat-Prod')
-        assert result is not None
+            result = fn(namespace='RedHat-Prod')
         assert result.status_code == 403
 
     @patch('utils.current_user')
     def test_none_namespace_allowed(self, mock_current_user):
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace(None)
-        assert result is None
+            result = fn(namespace=None)
+        assert result.status_code == 200
 
     @patch('utils.current_user')
     def test_blocks_all_protected_namespaces(self, mock_current_user):
         mock_current_user.realm_access = {'roles': ['admin-role']}
+        fn = _make_protected_fn()
         for ns in PROTECTED_AUTH_CONFIG['protected_namespaces']:
             with app.test_request_context():
-                result = check_protected_namespace(ns)
-            assert result is not None, f"Expected {ns} to be blocked"
-            assert result.status_code == 403
+                result = fn(namespace=ns)
+            assert result.status_code == 403, f"Expected {ns} to be blocked"
 
     @patch('utils.current_user')
     def test_blocks_when_no_realm_access(self, mock_current_user):
         mock_current_user.realm_access = None
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace('redhat')
-        assert result is not None
+            result = fn(namespace='redhat')
         assert result.status_code == 403
 
     def test_local_dev_bypass(self):
         app.config['test_auth'] = False
+        fn = _make_protected_fn()
         with app.test_request_context():
-            result = check_protected_namespace('redhat-prod')
-        assert result is None
+            result = fn(namespace='redhat-prod')
+        assert result.status_code == 200
+
+    @patch('utils.current_user')
+    def test_reads_namespace_from_request_body(self, mock_current_user):
+        mock_current_user.realm_access = {'roles': ['admin-role']}
+        fn = _make_protected_fn()
+        with app.test_request_context(json={"namespace": "redhat-prod"}):
+            result = fn()
+        assert result.status_code == 403
+
+    @patch('utils.current_user')
+    def test_no_namespace_passes_through(self, mock_current_user):
+        fn = _make_protected_fn()
+        with app.test_request_context():
+            result = fn()
+        assert result.status_code == 200
 
 
 class TestProtectedNamespaceEndpoints:

--- a/backend/tests/test_protected_namespace.py
+++ b/backend/tests/test_protected_namespace.py
@@ -1,0 +1,152 @@
+from unittest.mock import Mock, patch
+from app import app
+from utils import check_protected_namespace
+import pytest
+import json
+
+
+PROTECTED_AUTH_CONFIG = {
+    'url': 'https://auth.example.com/auth',
+    'clientid': 'test-client-id',
+    'realm': 'TestRealm',
+    'roles': {
+        'ADMIN_ROLE': 'admin-role',
+        'EXPORT_COMPLIANCE_ROLE': 'export-compliance-role',
+        'PROTECTED_ADMIN_ROLE': 'protected-admin-role',
+    },
+    'protected_namespaces': [
+        'openshift-release-dev',
+        'redhat-prod',
+        'redhat',
+        'redhat-user-workloads',
+        'openshift',
+        'redhat-pending',
+        'redhat-services-prod',
+        'redhat-services-pending',
+        'openshift-logging',
+        'openshift-pipeline',
+        'openshiftio',
+    ],
+}
+
+
+@pytest.fixture
+def client():
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def enable_auth():
+    original_local = app.config.get('is_local')
+    original_test_auth = app.config.get('test_auth')
+    original_auth = app.config.get('authentication')
+    app.config['is_local'] = True
+    app.config['test_auth'] = True
+    app.config['authentication'] = PROTECTED_AUTH_CONFIG
+    yield
+    app.config['is_local'] = original_local
+    app.config['test_auth'] = original_test_auth
+    app.config['authentication'] = original_auth
+
+
+def mock_user_with_roles(roles):
+    return Mock(
+        is_authenticated=True,
+        email='test@example.com',
+        username='Test User',
+        realm_access={'roles': roles},
+    )
+
+
+class TestCheckProtectedNamespace:
+
+    @patch('utils.current_user')
+    def test_blocks_protected_namespace_without_role(self, mock_current_user):
+        mock_current_user.realm_access = {'roles': ['admin-role']}
+        with app.test_request_context():
+            result = check_protected_namespace('redhat-prod')
+        assert result is not None
+        assert result.status_code == 403
+        assert b'protected' in result.data.lower()
+
+    @patch('utils.current_user')
+    def test_allows_protected_namespace_with_role(self, mock_current_user):
+        mock_current_user.realm_access = {'roles': ['admin-role', 'protected-admin-role']}
+        with app.test_request_context():
+            result = check_protected_namespace('redhat-prod')
+        assert result is None
+
+    @patch('utils.current_user')
+    def test_allows_non_protected_namespace(self, mock_current_user):
+        mock_current_user.realm_access = {'roles': ['admin-role']}
+        with app.test_request_context():
+            result = check_protected_namespace('some-random-user')
+        assert result is None
+
+    @patch('utils.current_user')
+    def test_case_insensitive_match(self, mock_current_user):
+        mock_current_user.realm_access = {'roles': ['admin-role']}
+        with app.test_request_context():
+            result = check_protected_namespace('RedHat-Prod')
+        assert result is not None
+        assert result.status_code == 403
+
+    @patch('utils.current_user')
+    def test_none_namespace_allowed(self, mock_current_user):
+        with app.test_request_context():
+            result = check_protected_namespace(None)
+        assert result is None
+
+    @patch('utils.current_user')
+    def test_blocks_all_protected_namespaces(self, mock_current_user):
+        mock_current_user.realm_access = {'roles': ['admin-role']}
+        for ns in PROTECTED_AUTH_CONFIG['protected_namespaces']:
+            with app.test_request_context():
+                result = check_protected_namespace(ns)
+            assert result is not None, f"Expected {ns} to be blocked"
+            assert result.status_code == 403
+
+    @patch('utils.current_user')
+    def test_blocks_when_no_realm_access(self, mock_current_user):
+        mock_current_user.realm_access = None
+        with app.test_request_context():
+            result = check_protected_namespace('redhat')
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_local_dev_bypass(self):
+        app.config['test_auth'] = False
+        with app.test_request_context():
+            result = check_protected_namespace('redhat-prod')
+        assert result is None
+
+
+class TestProtectedNamespaceEndpoints:
+
+    @patch('tasks.user.user')
+    def test_delete_protected_user_blocked(self, mock_user, client):
+        app.config['is_local'] = False
+        mock_user.get_namespace_user.return_value = Mock(
+            is_authenticated=True, realm_access={'roles': ['admin-role']},
+            email='test@example.com', username='Test User',
+        )
+        res = client.delete('/user/redhat-prod')
+        assert res.status_code in (401, 403)
+
+    @patch('tasks.user.user')
+    def test_enable_protected_user_blocked(self, mock_user, client):
+        app.config['is_local'] = False
+        mock_user.get_namespace_user.return_value = Mock(
+            is_authenticated=True, realm_access={'roles': ['admin-role']},
+            email='test@example.com', username='Test User',
+        )
+        res = client.put('/user/redhat-prod?enable=true')
+        assert res.status_code in (401, 403)
+
+    @patch('tasks.user.user')
+    def test_delete_non_protected_user_not_blocked_by_guard(self, mock_user, client):
+        app.config['test_auth'] = False
+        mock_user.get_namespace_user.return_value = Mock(id=1, username='some-user', enabled=True)
+        mock_user.mark_namespace_for_deletion.return_value = None
+        res = client.delete('/user/some-user')
+        assert res.status_code != 403

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -108,25 +108,37 @@ def verify_export_compliance_permissions(func):
     return wrapper
 
 
-def check_protected_namespace(namespace):
-    if not namespace:
-        return None
+def protect_namespace(param):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            namespace = kwargs.get(param)
+            if namespace is None:
+                body = request.get_json(silent=True)
+                if body:
+                    namespace = body.get(param)
+            if namespace is None:
+                namespace = request.values.get(param)
 
-    protected = app.config.get('authentication', {}).get('protected_namespaces', [])
-    if namespace.lower() not in [ns.lower() for ns in protected]:
-        return None
+            if not namespace:
+                return func(*args, **kwargs)
 
-    if app.config.get('is_local') and not app.config.get('test_auth'):
-        return None
+            protected = app.config.get('authentication', {}).get('protected_namespaces', [])
+            if namespace.lower() not in [ns.lower() for ns in protected]:
+                return func(*args, **kwargs)
 
-    PROTECTED_ADMIN_ROLE = app.config.get('authentication', {}).get('roles', {}).get('PROTECTED_ADMIN_ROLE')
-    if not current_user or not current_user.realm_access:
-        return make_response(json.dumps({"message": f"Namespace '{namespace}' is protected. Requires PROTECTED_ADMIN_ROLE."}), 403)
+            if app.config.get('is_local') and not app.config.get('test_auth'):
+                return func(*args, **kwargs)
 
-    if PROTECTED_ADMIN_ROLE not in current_user.realm_access.get('roles', []):
-        return make_response(json.dumps({"message": f"Namespace '{namespace}' is protected. Requires PROTECTED_ADMIN_ROLE."}), 403)
+            PROTECTED_ADMIN_ROLE = app.config.get('authentication', {}).get('roles', {}).get('PROTECTED_ADMIN_ROLE')
+            if not current_user or not current_user.realm_access:
+                return make_response(json.dumps({"message": f"Namespace '{namespace}' is protected. Requires PROTECTED_ADMIN_ROLE."}), 403)
 
-    return None
+            if PROTECTED_ADMIN_ROLE not in current_user.realm_access.get('roles', []):
+                return make_response(json.dumps({"message": f"Namespace '{namespace}' is protected. Requires PROTECTED_ADMIN_ROLE."}), 403)
+
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 
 def verify_admin_or_export_perm(func):

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -108,6 +108,27 @@ def verify_export_compliance_permissions(func):
     return wrapper
 
 
+def check_protected_namespace(namespace):
+    if not namespace:
+        return None
+
+    protected = app.config.get('authentication', {}).get('protected_namespaces', [])
+    if namespace.lower() not in [ns.lower() for ns in protected]:
+        return None
+
+    if app.config.get('is_local') and not app.config.get('test_auth'):
+        return None
+
+    PROTECTED_ADMIN_ROLE = app.config.get('authentication', {}).get('roles', {}).get('PROTECTED_ADMIN_ROLE')
+    if not current_user or not current_user.realm_access:
+        return make_response(json.dumps({"message": f"Namespace '{namespace}' is protected. Requires PROTECTED_ADMIN_ROLE."}), 403)
+
+    if PROTECTED_ADMIN_ROLE not in current_user.realm_access.get('roles', []):
+        return make_response(json.dumps({"message": f"Namespace '{namespace}' is protected. Requires PROTECTED_ADMIN_ROLE."}), 403)
+
+    return None
+
+
 def verify_admin_or_export_perm(func):
     def wrapper(*args, **kwargs):
         # Bypassing checks for local dev when auth is not on


### PR DESCRIPTION
Implements a new security feature for service-tool, requiring a higher level `PROTECTED_ADMIN_ROLE` to perform modifications to key Red Hat namespaces including Konflux & others. Most support engineers will not have this role and we'll instead delegate out to team managers to perform these kinds of changes. 

The namespaces are a static list defined on the configuration.

The check is implemented through a decorator that is applied on modifiable endpoints `PUT/DELETE/POST` but not on `GET` endpoints.

Claude Code Generated

https://redhat.atlassian.net/browse/QUAYIO-1716