### PR TITLE
fix(supervisor): use stdout_logfile instead of supervisor_stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,7 @@ ENTRYPOINT ["gunicorn", "-k", "gevent", "-b", "0.0.0.0:5000", "--limit-request-f
 
 FROM backend-base AS production
 
-ENV SERVICETOOL_RUN=/conf \
-    SERVICETOOL_LOGGING=syslog
+ENV SERVICETOOL_RUN=/conf
 
 COPY --chown=1001:0 ./conf /conf
 COPY --from=frontend-build --chown=1001:0 /frontend/dist /backend/static

--- a/conf/generate_supervisord_conf.sh
+++ b/conf/generate_supervisord_conf.sh
@@ -2,16 +2,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")"
-SERVICETOOL_LOGGING="${SERVICETOOL_LOGGING:-syslog}"
 CONFIG_FILE="./supervisord.conf"
-
-if [ "${SERVICETOOL_LOGGING}" = "stdout" ]; then
-  LOGGING_CMD="command=supervisor_stdout"
-  RESULT_HANDLER="supervisor_stdout:event_handler"
-else
-  LOGGING_CMD="command=supervisor_logging"
-  RESULT_HANDLER=""
-fi
 
 cat << EOF > ${CONFIG_FILE}
 [supervisord]
@@ -22,19 +13,8 @@ environment=
   PYTHONPATH=%(ENV_SERVICETOOLDIR)s
 command=gunicorn -k gevent -b 0.0.0.0:5000 --limit-request-field_size 16384 app:app
 autostart = true
-stdout_events_enabled = true
-stderr_events_enabled = true
-
-[eventlistener:stdout]
-environment=
-  PYTHONPATH=%(ENV_SERVICETOOLDIR)s
-buffer_size = 1024
-events = PROCESS_LOG
-${LOGGING_CMD}
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 EOF
-
-
-# Add result_handler only for stdout logging
-if [ -n "${RESULT_HANDLER}" ]; then
-  echo "result_handler=${RESULT_HANDLER}" >> ${CONFIG_FILE}
-fi

--- a/conf/supervisord.conf.example
+++ b/conf/supervisord.conf.example
@@ -6,13 +6,7 @@ environment=
   PYTHONPATH=%(ENV_SERVICETOOLDIR)s
 command=gunicorn -k gevent -b 0.0.0.0:5000 app:app
 autostart = true
-stdout_events_enabled = true
-stderr_events_enabled = true
-
-[eventlistener:stdout]
-environment=
-  PYTHONPATH=%(ENV_SERVICETOOLDIR)s
-command=supervisor_logging
-result_handler = supervisor_stdout:event_handler
-buffer_size = 1024
-events = PROCESS_LOG
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/openshift-rosa.yml
+++ b/openshift-rosa.yml
@@ -55,9 +55,6 @@ parameters:
   value: "128Mi"
 - name: QUAY_RESOURCES_LIMITS_MEMORY
   value: "256Mi"
-- name: SERVICETOOL_LOGGING
-  value: "syslog"
-  displayName: Service tool logging method
 objects:
 - apiVersion: apps/v1
   kind: Deployment
@@ -105,8 +102,6 @@ objects:
           env:
           - name: CONFIG_PATH
             value: ${{CONFIG_MOUNT_PATH}}
-          - name: SERVICETOOL_LOGGING
-            value: ${{SERVICETOOL_LOGGING}}
           livenessProbe:
             httpGet:
               path: /healthcheck


### PR DESCRIPTION
https://github.com/quay/quay-service-tool/pull/195/changes removed `supervisor_stdout` which was a regression and caused errors in stage.

In newer versions of supervisor we can use just the `stdout_logfile` rather than pulling in this dependency.

https://redhat.atlassian.net/browse/QUAYIO-1725