### PR TITLE
feat(spam): add spam detection review UI and rule management

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,6 +12,15 @@ from tasks.banner import BannerTask
 from tasks.username import UsernameTask
 from tasks.federateduser import FederatedUserTask
 from tasks.user import UserTask, FetchUserFromEmailTask, FetchUserFromNameTask, UpdateEmailTask, FetchUserFromStripeID
+from tasks.spam import (
+    SpamRuleListTask,
+    SpamRuleDetailTask,
+    FlaggedRepoListTask,
+    FlaggedRepoDetailTask,
+    QuarantineRepoTask,
+    RestoreRepoTask,
+    DismissRepoTask,
+)
 import yaml
 import logging
 from utils import *
@@ -111,6 +120,13 @@ api.add_resource(FederatedUserTask, '/federateduser/<username>')
 api.add_resource(UpdateEmailTask, '/user/email')
 api.add_resource(RobotTokenTask, '/robot/token')
 api.add_resource(AddOrgOwnerTask, '/org/owner')
+api.add_resource(SpamRuleListTask, '/spam/rules')
+api.add_resource(SpamRuleDetailTask, '/spam/rules/<rule_uuid>')
+api.add_resource(FlaggedRepoListTask, '/spam/flagged')
+api.add_resource(FlaggedRepoDetailTask, '/spam/flagged/<repo_uuid>')
+api.add_resource(QuarantineRepoTask, '/spam/flagged/<repo_uuid>/quarantine')
+api.add_resource(RestoreRepoTask, '/spam/flagged/<repo_uuid>/restore')
+api.add_resource(DismissRepoTask, '/spam/flagged/<repo_uuid>/dismiss')
 
 if __name__ == '__main__':
     app.run(debug=True, host="0.0.0.0")

--- a/backend/tasks/spam.py
+++ b/backend/tasks/spam.py
@@ -1,0 +1,230 @@
+from flask_restful import Resource, reqparse
+from flask_login import login_required
+from flask import make_response, request
+import json
+import logging
+
+from utils import log_response, verify_admin_permissions
+from data.model import spam, db_transaction
+
+logger = logging.getLogger(__name__)
+
+
+class SpamRuleListTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def get(self):
+        try:
+            rules = spam.get_spam_detection_rules()
+            return make_response(
+                json.dumps({"rules": [r.get_view() for r in rules]}), 200
+            )
+        except Exception as e:
+            logger.exception("Failed to list spam detection rules")
+            return make_response(
+                json.dumps({"message": "Failed to list rules"}), 500
+            )
+
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def post(self):
+        try:
+            data = request.get_json()
+            if not data or "name" not in data or "rule_type" not in data:
+                return make_response(
+                    json.dumps({"message": "name and rule_type are required"}), 400
+                )
+            rule = spam.create_spam_detection_rule(
+                name=data["name"],
+                rule_type=data["rule_type"],
+                pattern=data.get("pattern"),
+                config=data.get("config"),
+                confidence_score=data.get("confidence_score", 50),
+            )
+            return make_response(json.dumps(rule.get_view()), 201)
+        except spam.InvalidSpamDetectionRule as e:
+            return make_response(json.dumps({"message": str(e)}), 400)
+        except Exception as e:
+            logger.exception("Failed to create spam detection rule")
+            return make_response(
+                json.dumps({"message": "Failed to create rule"}), 500
+            )
+
+
+class SpamRuleDetailTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def get(self, rule_uuid):
+        try:
+            rule = spam.get_spam_detection_rule_by_uuid(rule_uuid)
+            if not rule:
+                return make_response(
+                    json.dumps({"message": "Rule not found"}), 404
+                )
+            return make_response(json.dumps(rule.get_view()), 200)
+        except Exception as e:
+            logger.exception("Failed to get spam detection rule")
+            return make_response(
+                json.dumps({"message": "Failed to get rule"}), 500
+            )
+
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def put(self, rule_uuid):
+        try:
+            data = request.get_json()
+            if not data:
+                return make_response(
+                    json.dumps({"message": "Request body is required"}), 400
+                )
+            spam.update_spam_detection_rule(rule_uuid, **data)
+            rule = spam.get_spam_detection_rule_by_uuid(rule_uuid)
+            return make_response(json.dumps(rule.get_view()), 200)
+        except spam.SpamDetectionRuleNotFound:
+            return make_response(
+                json.dumps({"message": "Rule not found"}), 404
+            )
+        except spam.InvalidSpamDetectionRule as e:
+            return make_response(json.dumps({"message": str(e)}), 400)
+        except Exception as e:
+            logger.exception("Failed to update spam detection rule")
+            return make_response(
+                json.dumps({"message": "Failed to update rule"}), 500
+            )
+
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def delete(self, rule_uuid):
+        try:
+            spam.delete_spam_detection_rule(rule_uuid)
+            return make_response(json.dumps({"message": "Rule deleted"}), 200)
+        except spam.SpamDetectionRuleNotFound:
+            return make_response(
+                json.dumps({"message": "Rule not found"}), 404
+            )
+        except Exception as e:
+            logger.exception("Failed to delete spam detection rule")
+            return make_response(
+                json.dumps({"message": "Failed to delete rule"}), 500
+            )
+
+
+class FlaggedRepoListTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def get(self):
+        try:
+            parser = reqparse.RequestParser()
+            parser.add_argument("status", type=str, location="args")
+            parser.add_argument("min_confidence", type=int, default=0, location="args")
+            parser.add_argument("namespace", type=str, location="args")
+            parser.add_argument("scan_id", type=str, location="args")
+            parser.add_argument("page_token", type=str, location="args")
+            parser.add_argument("limit", type=int, default=50, location="args")
+            args = parser.parse_args()
+
+            repos, next_token = spam.get_quarantined_repos(
+                status=args.get("status"),
+                min_confidence=args.get("min_confidence", 0),
+                namespace=args.get("namespace"),
+                scan_id=args.get("scan_id"),
+                page_token=args.get("page_token"),
+                limit=min(args.get("limit", 50), 100),
+            )
+            result = {"flagged_repos": [r.get_view() for r in repos]}
+            if next_token:
+                result["next_page_token"] = next_token
+            return make_response(json.dumps(result), 200)
+        except Exception as e:
+            logger.exception("Failed to list flagged repos")
+            return make_response(
+                json.dumps({"message": "Failed to list flagged repos"}), 500
+            )
+
+
+class FlaggedRepoDetailTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def get(self, repo_uuid):
+        try:
+            repo = spam.get_quarantined_repo_by_uuid(repo_uuid)
+            if not repo:
+                return make_response(
+                    json.dumps({"message": "Flagged repo not found"}), 404
+                )
+            return make_response(json.dumps(repo.get_view()), 200)
+        except Exception as e:
+            logger.exception("Failed to get flagged repo")
+            return make_response(
+                json.dumps({"message": "Failed to get flagged repo"}), 500
+            )
+
+
+class QuarantineRepoTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def post(self, repo_uuid):
+        try:
+            from flask_login import current_user
+            actioned_by = getattr(current_user, "username", "admin")
+            spam.quarantine_repository(repo_uuid, actioned_by)
+            return make_response(json.dumps({"status": "quarantined"}), 200)
+        except spam.QuarantinedRepoNotFound:
+            return make_response(
+                json.dumps({"message": "Flagged repo not found"}), 404
+            )
+        except Exception as e:
+            logger.exception("Failed to quarantine repo")
+            return make_response(
+                json.dumps({"message": "Failed to quarantine repo"}), 500
+            )
+
+
+class RestoreRepoTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def post(self, repo_uuid):
+        try:
+            from flask_login import current_user
+            actioned_by = getattr(current_user, "username", "admin")
+            spam.restore_repository(repo_uuid, actioned_by)
+            return make_response(json.dumps({"status": "restored"}), 200)
+        except spam.QuarantinedRepoNotFound:
+            return make_response(
+                json.dumps({"message": "Flagged repo not found"}), 404
+            )
+        except Exception as e:
+            logger.exception("Failed to restore repo")
+            return make_response(
+                json.dumps({"message": "Failed to restore repo"}), 500
+            )
+
+
+class DismissRepoTask(Resource):
+    @log_response
+    @verify_admin_permissions
+    @login_required
+    def post(self, repo_uuid):
+        try:
+            from flask_login import current_user
+            actioned_by = getattr(current_user, "username", "admin")
+            spam.dismiss_quarantined_repo(repo_uuid, actioned_by)
+            return make_response(json.dumps({"status": "dismissed"}), 200)
+        except spam.QuarantinedRepoNotFound:
+            return make_response(
+                json.dumps({"message": "Flagged repo not found"}), 404
+            )
+        except Exception as e:
+            logger.exception("Failed to dismiss repo")
+            return make_response(
+                json.dumps({"message": "Failed to dismiss repo"}), 500
+            )

--- a/frontend/src/app/SpamDetection/SpamDetection.tsx
+++ b/frontend/src/app/SpamDetection/SpamDetection.tsx
@@ -1,0 +1,508 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  CardBody,
+  CardTitle,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Modal,
+  ModalVariant,
+  PageSection,
+  Spinner,
+  Split,
+  SplitItem,
+  Tab,
+  Tabs,
+  TabTitleText,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { useState, useEffect } from 'react';
+import HttpService from 'src/services/HttpService';
+import { getErrorMessage } from '@app/utils/utils';
+
+type SpamRule = {
+  uuid: string;
+  name: string;
+  rule_type: string;
+  pattern: string | null;
+  config: Record<string, unknown>;
+  confidence_score: number;
+  enabled: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+type FlaggedRepo = {
+  uuid: string;
+  namespace_name: string;
+  repository_name: string;
+  status: string;
+  original_description: string | null;
+  matched_rules: Array<{
+    rule_uuid: string;
+    rule_name: string;
+    rule_type: string;
+    confidence: number;
+  }>;
+  total_confidence_score: number;
+  is_empty: boolean;
+  scan_id: string | null;
+  actioned_by: string | null;
+  actioned_at: string | null;
+  created_at: string | null;
+};
+
+const RULE_TYPES = [
+  { value: 'keyword', label: 'Keyword Match' },
+  { value: 'url_pattern', label: 'URL Pattern (Regex)' },
+  { value: 'repo_name_pattern', label: 'Repository Name Pattern (Regex)' },
+  { value: 'empty_repo', label: 'Empty Repository' },
+  { value: 'account_age', label: 'Account Age' },
+];
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All Statuses' },
+  { value: 'flagged', label: 'Flagged' },
+  { value: 'quarantined', label: 'Quarantined' },
+  { value: 'restored', label: 'Restored' },
+  { value: 'dismissed', label: 'Dismissed' },
+];
+
+export const SpamDetection: React.FunctionComponent = () => {
+  const [activeTab, setActiveTab] = useState<string | number>(0);
+
+  // Rules state
+  const [rules, setRules] = useState<SpamRule[]>([]);
+  const [rulesLoading, setRulesLoading] = useState(false);
+  const [rulesError, setRulesError] = useState('');
+
+  // Create rule state
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newRuleName, setNewRuleName] = useState('');
+  const [newRuleType, setNewRuleType] = useState('keyword');
+  const [newRulePattern, setNewRulePattern] = useState('');
+  const [newRuleConfidence, setNewRuleConfidence] = useState(50);
+
+  // Flagged repos state
+  const [flaggedRepos, setFlaggedRepos] = useState<FlaggedRepo[]>([]);
+  const [reposLoading, setReposLoading] = useState(false);
+  const [reposError, setReposError] = useState('');
+  const [statusFilter, setStatusFilter] = useState('flagged');
+
+  // Detail modal
+  const [selectedRepo, setSelectedRepo] = useState<FlaggedRepo | null>(null);
+  const [showDetailModal, setShowDetailModal] = useState(false);
+
+  // Feedback
+  const [feedback, setFeedback] = useState<{
+    variant: 'success' | 'danger' | 'info';
+    message: string;
+    show: boolean;
+  }>({ variant: 'success', message: '', show: false });
+
+  const loadRules = () => {
+    setRulesLoading(true);
+    setRulesError('');
+    HttpService.axiosClient
+      .get('/spam/rules')
+      .then((response) => {
+        setRules(response.data.rules || []);
+        setRulesLoading(false);
+      })
+      .catch((error) => {
+        setRulesError(getErrorMessage(error));
+        setRulesLoading(false);
+      });
+  };
+
+  const loadFlaggedRepos = () => {
+    setReposLoading(true);
+    setReposError('');
+    const params: Record<string, string | number> = { limit: 50 };
+    if (statusFilter) params.status = statusFilter;
+    HttpService.axiosClient
+      .get('/spam/flagged', { params })
+      .then((response) => {
+        setFlaggedRepos(response.data.flagged_repos || []);
+        setReposLoading(false);
+      })
+      .catch((error) => {
+        setReposError(getErrorMessage(error));
+        setReposLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    loadRules();
+  }, []);
+
+  useEffect(() => {
+    loadFlaggedRepos();
+  }, [statusFilter]);
+
+  const createRule = () => {
+    HttpService.axiosClient
+      .post('/spam/rules', {
+        name: newRuleName,
+        rule_type: newRuleType,
+        pattern: newRulePattern || undefined,
+        confidence_score: newRuleConfidence,
+      })
+      .then(() => {
+        setShowCreateModal(false);
+        setNewRuleName('');
+        setNewRulePattern('');
+        setNewRuleConfidence(50);
+        setFeedback({ variant: 'success', message: 'Rule created', show: true });
+        loadRules();
+      })
+      .catch((error) => {
+        setFeedback({ variant: 'danger', message: getErrorMessage(error), show: true });
+      });
+  };
+
+  const deleteRule = (uuid: string) => {
+    HttpService.axiosClient
+      .delete(`/spam/rules/${uuid}`)
+      .then(() => {
+        setFeedback({ variant: 'success', message: 'Rule deleted', show: true });
+        loadRules();
+      })
+      .catch((error) => {
+        setFeedback({ variant: 'danger', message: getErrorMessage(error), show: true });
+      });
+  };
+
+  const toggleRule = (rule: SpamRule) => {
+    HttpService.axiosClient
+      .put(`/spam/rules/${rule.uuid}`, { enabled: !rule.enabled })
+      .then(() => {
+        loadRules();
+      })
+      .catch((error) => {
+        setFeedback({ variant: 'danger', message: getErrorMessage(error), show: true });
+      });
+  };
+
+  const actionRepo = (uuid: string, action: string) => {
+    HttpService.axiosClient
+      .post(`/spam/flagged/${uuid}/${action}`)
+      .then(() => {
+        setFeedback({ variant: 'success', message: `Repository ${action}d`, show: true });
+        loadFlaggedRepos();
+      })
+      .catch((error) => {
+        setFeedback({ variant: 'danger', message: getErrorMessage(error), show: true });
+      });
+  };
+
+  return (
+    <PageSection>
+      <Title headingLevel="h1" style={{ marginBottom: '1rem' }}>
+        Spam Detection
+      </Title>
+
+      {feedback.show && (
+        <Alert
+          variant={feedback.variant}
+          title={feedback.message}
+          isInline
+          actionClose={
+            <Button variant="plain" onClick={() => setFeedback({ ...feedback, show: false })}>
+              &times;
+            </Button>
+          }
+          style={{ marginBottom: '1rem' }}
+        />
+      )}
+
+      <Tabs activeKey={activeTab} onSelect={(_e, key) => setActiveTab(key)}>
+        <Tab eventKey={0} title={<TabTitleText>Flagged Repositories</TabTitleText>}>
+          <Card style={{ marginTop: '1rem' }}>
+            <CardBody>
+              <Split hasGutter style={{ marginBottom: '1rem' }}>
+                <SplitItem>
+                  <FormSelect
+                    value={statusFilter}
+                    onChange={(_e, val) => setStatusFilter(val)}
+                    style={{ width: '200px' }}
+                    aria-label="Filter by status"
+                  >
+                    {STATUS_OPTIONS.map((opt) => (
+                      <FormSelectOption key={opt.value} value={opt.value} label={opt.label} />
+                    ))}
+                  </FormSelect>
+                </SplitItem>
+                <SplitItem>
+                  <Button variant="secondary" onClick={loadFlaggedRepos}>
+                    Refresh
+                  </Button>
+                </SplitItem>
+              </Split>
+
+              {reposLoading ? (
+                <Spinner size="lg" />
+              ) : reposError ? (
+                <Alert variant="danger" title={reposError} isInline />
+              ) : flaggedRepos.length === 0 ? (
+                <p>No flagged repositories found.</p>
+              ) : (
+                <table className="pf-v5-c-table pf-m-compact" role="grid">
+                  <thead>
+                    <tr>
+                      <th>Repository</th>
+                      <th>Status</th>
+                      <th>Confidence</th>
+                      <th>Rules</th>
+                      <th>Empty</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {flaggedRepos.map((repo) => (
+                      <tr key={repo.uuid}>
+                        <td>
+                          <Button
+                            variant="link"
+                            isInline
+                            onClick={() => {
+                              setSelectedRepo(repo);
+                              setShowDetailModal(true);
+                            }}
+                          >
+                            {repo.namespace_name}/{repo.repository_name}
+                          </Button>
+                        </td>
+                        <td>{repo.status}</td>
+                        <td>{repo.total_confidence_score}</td>
+                        <td>{repo.matched_rules?.length || 0}</td>
+                        <td>{repo.is_empty ? 'Yes' : 'No'}</td>
+                        <td>
+                          {repo.status === 'flagged' && (
+                            <>
+                              <Button
+                                variant="danger"
+                                isSmall
+                                onClick={() => actionRepo(repo.uuid, 'quarantine')}
+                                style={{ marginRight: '0.5rem' }}
+                              >
+                                Quarantine
+                              </Button>
+                              <Button
+                                variant="secondary"
+                                isSmall
+                                onClick={() => actionRepo(repo.uuid, 'dismiss')}
+                              >
+                                Dismiss
+                              </Button>
+                            </>
+                          )}
+                          {repo.status === 'quarantined' && (
+                            <Button
+                              variant="secondary"
+                              isSmall
+                              onClick={() => actionRepo(repo.uuid, 'restore')}
+                            >
+                              Restore
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </CardBody>
+          </Card>
+        </Tab>
+
+        <Tab eventKey={1} title={<TabTitleText>Rules</TabTitleText>}>
+          <Card style={{ marginTop: '1rem' }}>
+            <CardBody>
+              <Button
+                variant="primary"
+                onClick={() => setShowCreateModal(true)}
+                style={{ marginBottom: '1rem' }}
+              >
+                Create Rule
+              </Button>
+
+              {rulesLoading ? (
+                <Spinner size="lg" />
+              ) : rulesError ? (
+                <Alert variant="danger" title={rulesError} isInline />
+              ) : rules.length === 0 ? (
+                <p>No detection rules configured.</p>
+              ) : (
+                <table className="pf-v5-c-table pf-m-compact" role="grid">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Type</th>
+                      <th>Pattern</th>
+                      <th>Confidence</th>
+                      <th>Enabled</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rules.map((rule) => (
+                      <tr key={rule.uuid}>
+                        <td>{rule.name}</td>
+                        <td>
+                          {RULE_TYPES.find((t) => t.value === rule.rule_type)?.label ||
+                            rule.rule_type}
+                        </td>
+                        <td>{rule.pattern || '-'}</td>
+                        <td>{rule.confidence_score}</td>
+                        <td>{rule.enabled ? 'Yes' : 'No'}</td>
+                        <td>
+                          <Button
+                            variant="secondary"
+                            isSmall
+                            onClick={() => toggleRule(rule)}
+                            style={{ marginRight: '0.5rem' }}
+                          >
+                            {rule.enabled ? 'Disable' : 'Enable'}
+                          </Button>
+                          <Button
+                            variant="danger"
+                            isSmall
+                            onClick={() => deleteRule(rule.uuid)}
+                          >
+                            Delete
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </CardBody>
+          </Card>
+        </Tab>
+      </Tabs>
+
+      {/* Create Rule Modal */}
+      <Modal
+        variant={ModalVariant.medium}
+        title="Create Detection Rule"
+        isOpen={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        actions={[
+          <Button key="create" variant="primary" onClick={createRule} isDisabled={!newRuleName}>
+            Create
+          </Button>,
+          <Button key="cancel" variant="link" onClick={() => setShowCreateModal(false)}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        <Form>
+          <FormGroup label="Name" isRequired fieldId="rule-name">
+            <TextInput
+              id="rule-name"
+              value={newRuleName}
+              onChange={(_e, val) => setNewRuleName(val)}
+              isRequired
+            />
+          </FormGroup>
+          <FormGroup label="Rule Type" isRequired fieldId="rule-type">
+            <FormSelect
+              id="rule-type"
+              value={newRuleType}
+              onChange={(_e, val) => setNewRuleType(val)}
+            >
+              {RULE_TYPES.map((t) => (
+                <FormSelectOption key={t.value} value={t.value} label={t.label} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+          {newRuleType !== 'empty_repo' && newRuleType !== 'account_age' && (
+            <FormGroup
+              label="Pattern"
+              fieldId="rule-pattern"
+              helperText={
+                newRuleType === 'keyword'
+                  ? 'Comma-separated keywords'
+                  : 'Regular expression'
+              }
+            >
+              <TextInput
+                id="rule-pattern"
+                value={newRulePattern}
+                onChange={(_e, val) => setNewRulePattern(val)}
+              />
+            </FormGroup>
+          )}
+          <FormGroup label="Confidence Score (0-100)" fieldId="rule-confidence">
+            <TextInput
+              id="rule-confidence"
+              type="number"
+              value={newRuleConfidence}
+              onChange={(_e, val) => setNewRuleConfidence(parseInt(val) || 0)}
+              min={0}
+              max={100}
+            />
+          </FormGroup>
+        </Form>
+      </Modal>
+
+      {/* Detail Modal */}
+      <Modal
+        variant={ModalVariant.large}
+        title={
+          selectedRepo
+            ? `${selectedRepo.namespace_name}/${selectedRepo.repository_name}`
+            : ''
+        }
+        isOpen={showDetailModal}
+        onClose={() => setShowDetailModal(false)}
+        actions={[
+          <Button key="close" variant="link" onClick={() => setShowDetailModal(false)}>
+            Close
+          </Button>,
+        ]}
+      >
+        {selectedRepo && (
+          <div>
+            <p>
+              <strong>Status:</strong> {selectedRepo.status}
+            </p>
+            <p>
+              <strong>Confidence Score:</strong> {selectedRepo.total_confidence_score}
+            </p>
+            <p>
+              <strong>Empty:</strong> {selectedRepo.is_empty ? 'Yes' : 'No'}
+            </p>
+            <p>
+              <strong>Original Description:</strong>{' '}
+              {selectedRepo.original_description || '(none)'}
+            </p>
+            <p>
+              <strong>Matched Rules:</strong>
+            </p>
+            <ul>
+              {selectedRepo.matched_rules?.map((r, i) => (
+                <li key={i}>
+                  {r.rule_name} ({r.rule_type}) - confidence: {r.confidence}
+                </li>
+              ))}
+            </ul>
+            {selectedRepo.actioned_by && (
+              <p>
+                <strong>Actioned By:</strong> {selectedRepo.actioned_by} at{' '}
+                {selectedRepo.actioned_at}
+              </p>
+            )}
+          </div>
+        )}
+      </Modal>
+    </PageSection>
+  );
+};

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -5,6 +5,7 @@ import UserService from "src/services/UserService";
 import { SiteUtils } from '@app/SiteUtils/SiteUtils';
 import { UserUtils } from '@app/UserUtils/UserUtils';
 import { ExportCompliance } from '@app/ExportCompliance/ExportCompliance';
+import { SpamDetection } from '@app/SpamDetection/SpamDetection';
 import { NotFound } from '@app/NotFound/NotFound';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
@@ -59,6 +60,15 @@ const routes: AppRouteConfig[] = [
     path: '/export-compliance',
     title: 'Quay Service Tool | Export Compliance',
     permission: ExportPerms
+  },
+  {
+    component: SpamDetection,
+    exact: true,
+    isAsync: true,
+    label: 'Spam Detection',
+    path: '/spam-detection',
+    title: 'Quay Service Tool | Spam Detection',
+    permission: AdminPerms,
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds backend API endpoints for spam detection rule CRUD and flagged repository management (quarantine, restore, dismiss actions) using Keycloak RBAC
- Adds frontend SpamDetection page with two tabs: Flagged Repositories (filterable by status, with action buttons) and Rules (create, enable/disable, delete)
- Companion to [quay/quay#5933](https://github.com/quay/quay/pull/5933) — provides the review and rule management interface that connects to the upstream spam detection data layer

### API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/spam/rules` | List all detection rules |
| `POST` | `/spam/rules` | Create a rule |
| `PUT` | `/spam/rules/<uuid>` | Update a rule |
| `DELETE` | `/spam/rules/<uuid>` | Delete a rule |
| `GET` | `/spam/flagged` | List flagged repos (filterable) |
| `GET` | `/spam/flagged/<uuid>` | Get flagged repo detail |
| `POST` | `/spam/flagged/<uuid>/quarantine` | Quarantine repo |
| `POST` | `/spam/flagged/<uuid>/restore` | Restore repo |
| `POST` | `/spam/flagged/<uuid>/dismiss` | Dismiss as false positive |

### Files Changed
- `backend/tasks/spam.py` — 7 Flask-RESTful resource classes
- `backend/app.py` — endpoint registration
- `frontend/src/app/SpamDetection/SpamDetection.tsx` — React/PatternFly UI
- `frontend/src/app/routes.tsx` — route registration

## Test plan
- [ ] Verify endpoints require admin permissions (Keycloak RBAC)
- [ ] Test rule CRUD lifecycle (create, list, update, toggle, delete)
- [ ] Test flagged repo listing with status filter
- [ ] Test quarantine/restore/dismiss actions return correct status
- [ ] Verify frontend renders both tabs correctly
- [ ] Verify route appears in navigation for admin users only

🤖 Generated with [Claude Code](https://claude.com/claude-code)