### PR TITLE
feat: load marketplace API certs from config

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -76,6 +76,23 @@ app.config["DB_CONNECTION_ARGS"] = conn_args
 app.config["DB_TRANSACTION_FACTORY"] = create_transaction
 database.configure(app.config)
 
+# Write marketplace certs from config to disk so MarketplaceUserApi
+# can read them from the expected paths (/conf/stack/quay-marketplace-api.{crt,key}).
+# In production, these values come from the app-interface secret config.
+from util.marketplace import MARKETPLACE_FILE, MARKETPLACE_SECRET
+
+for config_key, file_path in [
+    ("MARKETPLACE_CERT", MARKETPLACE_FILE),
+    ("MARKETPLACE_KEY", MARKETPLACE_SECRET),
+]:
+    content = app.config.get(config_key)
+    if content:
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "w") as f:
+            f.write(content)
+        os.chmod(file_path, 0o600)
+        logger.info("Wrote %s from config", file_path)
+
 marketplace_users = MarketplaceUserApi(app)
 
 

--- a/backend/config/config.yaml
+++ b/backend/config/config.yaml
@@ -30,11 +30,15 @@ authentication:
     - openshiftio
 # Red Hat Marketplace API configuration
 # In production, set FEATURE_RH_MARKETPLACE to true and provide the
-# API endpoints. The service tool must also have access to the same
-# marketplace certs as quay (/conf/stack/quay-marketplace-api.crt/.key).
+# API endpoints and certs. The cert/key values should match the ones
+# used by quay (from app-interface secret config).
 FEATURE_RH_MARKETPLACE: false
 ENTITLEMENT_RECONCILIATION_USER_ENDPOINT: ""
 ENTITLEMENT_RECONCILIATION_MARKETPLACE_ENDPOINT: ""
+# PEM-encoded marketplace API cert and key (same as quay's
+# quay-marketplace-api.crt/.key). Written to /conf/stack/ on startup.
+# MARKETPLACE_CERT: <PEM-encoded certificate>
+# MARKETPLACE_KEY: <PEM-encoded private key>
 
 ENV: development
 DEBUG: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,6 @@ services:
       - ./backend/templates:/backend/templates
       - ./backend/config:/backend/config
       - ./backend/tests:/backend/tests
-      # Mount marketplace certs from quay's conf/stack if available
-      # - ./conf/stack/quay-marketplace-api.crt:/conf/stack/quay-marketplace-api.crt:ro
-      # - ./conf/stack/quay-marketplace-api.key:/conf/stack/quay-marketplace-api.key:ro
     ports:
       - '5000:5000'
     environment:


### PR DESCRIPTION
## Summary

- Add `MARKETPLACE_CERT` and `MARKETPLACE_KEY` config fields to load marketplace API certificates inline from the config YAML
- Matches how quay loads certs via app-interface secret config (`quay-config.secret.yaml`)
- On startup, if these fields are present, cert/key content is written to `/conf/stack/quay-marketplace-api.{crt,key}` so the existing `MarketplaceUserApi` reads them from the expected paths
- Removed stale commented-out cert volume mounts from docker-compose (no longer needed since certs come from config)

## Test plan

- [x] All 33 backend unit tests pass
- [x] For production: set `FEATURE_RH_MARKETPLACE: true`, provide the `ENTITLEMENT_RECONCILIATION_USER_ENDPOINT`, and add `MARKETPLACE_CERT`/`MARKETPLACE_KEY` with the same PEM values used by quay
- [x] For local dev: no changes needed — `FakeUserApi` is used when marketplace is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)