### PR TITLE
fix(backend): add error logging and stop leaking exceptions

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -106,10 +106,11 @@ def healthcheck():
         database.db.close()
         return make_response(jsonify({'message': 'Healthy'}), 200)
     except Exception as e:
+        logger.error("Healthcheck failed", exc_info=True)
         if database.db.obj is not None and not database.db.is_closed():
-            logging.info("Closing database connection")
+            logger.info("Closing database connection")
             database.db.close()
-        return make_response(jsonify({'message': 'DB is not up: {}'.format(str(e))}), 503)
+        return make_response(jsonify({'message': 'Service unavailable'}), 503)
 
 
 @app.route("/")

--- a/backend/tasks/banner.py
+++ b/backend/tasks/banner.py
@@ -1,12 +1,15 @@
+import json
+import logging
+
 from flask_login import login_required
-from flask_restful import Resource
+from flask_restful import Resource, reqparse
 from flask import make_response
-from flask_restful import reqparse
 from playhouse.shortcuts import model_to_dict
 from utils import is_valid_severity, log_response, verify_admin_permissions
-import json
 from data.model import message, db_transaction
 from data.database import Messages
+
+logger = logging.getLogger(__name__)
 
 
 class BannerTask(Resource):
@@ -18,6 +21,7 @@ class BannerTask(Resource):
             messages = {"messages": [model_to_dict(m) for m in message.get_messages()]}
             return make_response(json.dumps(messages), 200)
         except Exception as e:
+            logger.error("Unable to fetch banners", exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to fetch banners"}), 500
             )
@@ -49,7 +53,7 @@ class BannerTask(Resource):
                 )
             return make_response(json.dumps({"message": "Banner created"}), 201)
         except Exception as e:
-            print(e)
+            logger.error("Unable to create banner", exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to create a new banner"}), 500
             )
@@ -81,6 +85,7 @@ class BannerTask(Resource):
                 ).execute()
             return make_response("updated", 200)
         except Exception as e:
+            logger.error("Unable to update banner", exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to update the banner"}), 500
             )
@@ -94,6 +99,7 @@ class BannerTask(Resource):
         except Messages.DoesNotExist:
             return make_response("Banner not found", 404)
         except Exception as e:
+            logger.error("Unable to check banner existence", exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to check banner existence"}), 500
             )
@@ -103,6 +109,7 @@ class BannerTask(Resource):
                 Messages.delete().where(Messages.id == id).execute()
             return make_response("deleted", 200)
         except Exception as e:
+            logger.error("Unable to delete banner", exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to delete the banner"}), 500
             )

--- a/backend/tasks/federateduser.py
+++ b/backend/tasks/federateduser.py
@@ -1,10 +1,13 @@
+import json
+import logging
+
 from flask_login import login_required
 from flask_restful import Resource
 from flask import make_response
-import json
-
 from utils import log_response, verify_export_compliance_permissions
 from data.model import user
+
+logger = logging.getLogger(__name__)
 
 
 class FederatedUserTask(Resource):
@@ -43,7 +46,8 @@ class FederatedUserTask(Resource):
                 200,
             )
         # Same output for Quay username/email search.
-        except Exception:
+        except Exception as e:
+            logger.error("Unable to fetch federated user %s", username, exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to fetch user"}), 500
             )

--- a/backend/tasks/robot_token.py
+++ b/backend/tasks/robot_token.py
@@ -1,5 +1,8 @@
 import json
+import logging
 from typing import Union
+
+logger = logging.getLogger(__name__)
 
 from flask import make_response
 from flask_login import login_required
@@ -52,8 +55,9 @@ class RobotTokenTask(Resource):
         try:
             user.create_robot(robot_shortname=robot_name, parent=parent, token=token)
         except Union[DataModelException, InvalidRobotException] as e:
+            logger.error("Failed to create robot token", exc_info=True)
             return make_response(
-                json.dumps({"message": f"ERROR: {e}"}), 400
+                json.dumps({"message": "Failed to create robot token"}), 400
             )
 
         return make_response(

--- a/backend/tasks/user.py
+++ b/backend/tasks/user.py
@@ -2,6 +2,9 @@ from flask_restful import Resource, reqparse, inputs
 from flask_login import login_required
 from flask import make_response, current_app
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 from utils import create_transaction as tf, log_response, verify_admin_permissions, verify_export_compliance_permissions, verify_admin_or_export_perm, protect_namespace
 from data.model import user, db_transaction
@@ -70,6 +73,7 @@ class UserTask(Resource):
                 200,
             )
         except Exception as e:
+            logger.error("Unable to fetch user %s", username, exc_info=True)
             return make_response(
                 json.dumps({"message": f"Unable to fetch user {username}"}), 500
             )
@@ -112,6 +116,7 @@ class UserTask(Resource):
                 found_user.save()
                 
         except Exception as e:
+            logger.error("Unable to update enable status for %s", username, exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to update enable status"}), 500
             )
@@ -185,6 +190,7 @@ class FetchUserFromNameTask(Resource):
                 200,
             )
         except Exception as e:
+            logger.error("Unable to fetch user %s", quayusername, exc_info=True)
             return make_response(
                 json.dumps({"message": f"Unable to fetch user {quayusername}"}), 500
             )
@@ -228,6 +234,7 @@ class FetchUserFromEmailTask(Resource):
                 200,
             )
         except Exception as e:
+            logger.error("Unable to fetch user by email", exc_info=True)
             return make_response(
                 json.dumps({"message": f"Unable to fetch user {quayuseremail}"}), 500
             )
@@ -268,6 +275,7 @@ class FetchUserFromStripeID(Resource):
                 200,
             )
         except Exception as e:
+            logger.error("Unable to fetch user by stripe ID", exc_info=True)
             return make_response(
                 json.dumps({"message": f"Unable to fetch user with stripe ID {stripe_id}"}), 500
             )
@@ -295,15 +303,13 @@ class UpdateEmailTask(Resource):
             user.update_email(curr_user, new_email, True)
             return make_response(f"email for user {username} has been updated to {new_email}", 200)
         except DataModelException as e:
+            logger.error("Failed to update email for user %s", username, exc_info=True)
             return make_response(
-                json.dumps(
-                    {
-                        "message": str(e)
-                    }
-                ),
+                json.dumps({"message": "Failed to update email"}),
                 400,
             )
         except Exception as e:
+            logger.error("Failed to update email for user %s", username, exc_info=True)
             return make_response(
-                json.dumps({"message": "Unable to update the username" + str(e)}), 500
+                json.dumps({"message": "Unable to update email"}), 500
             )

--- a/backend/tasks/username.py
+++ b/backend/tasks/username.py
@@ -1,11 +1,14 @@
-from flask_restful import Resource
+import json
+import logging
+
+from flask_restful import Resource, reqparse
 from flask_login import login_required
 from flask import make_response
-from flask_restful import reqparse
 from data import model
 from data.model import InvalidUsernameException, user
 from utils import log_response, verify_admin_permissions, protect_namespace
-import json
+
+logger = logging.getLogger(__name__)
 
 
 class UsernameTask(Resource):
@@ -45,6 +48,7 @@ class UsernameTask(Resource):
                 400,
             )
         except Exception as e:
+            logger.error("Unable to update username for %s", current_user_name, exc_info=True)
             return make_response(
                 json.dumps({"message": "Unable to update the username"}), 500
             )


### PR DESCRIPTION
Exception details (DB errors, internal state) were being returned in HTTP response bodies across all task handlers, and most except blocks had no logging at all — making failures invisible in pod logs. Now all handlers log with exc_info=True for full tracebacks and return generic messages.

