### PR TITLE
QUAYIO-1921: fix(frontend): upgrade js-yaml to 3.15.0 to fix CVE-2026-59869

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,8 @@
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
     "overrides": {
-      "tar": "^7.5.7"
+      "tar": "^7.5.7",
+      "js-yaml": "^3.15.0"
     }
   },
   "version": "0.0.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   tar: ^7.5.7
+  js-yaml: ^3.15.0
 
 importers:
 
@@ -4808,8 +4809,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   jsdom@16.7.0:
@@ -8978,7 +8979,7 @@ snapshots:
       globals: 13.24.0
       ignore: 4.0.6
       import-fresh: 3.3.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9012,7 +9013,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -9137,7 +9138,11 @@ snapshots:
       jest-runner: 26.6.3
       jest-runtime: 26.6.3
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   '@jest/transform@26.6.2':
     dependencies:
@@ -11908,7 +11913,7 @@ snapshots:
     dependencies:
       import-fresh: 2.0.0
       is-directory: 0.3.1
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       parse-json: 4.0.0
 
   cosmiconfig@6.0.0:
@@ -12839,7 +12844,7 @@ snapshots:
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -14414,7 +14419,11 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:
@@ -14619,7 +14628,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -17294,7 +17303,7 @@ snapshots:
       css-select-base-adapter: 0.1.1
       css-tree: 1.0.0-alpha.37
       csso: 4.2.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       mkdirp: 0.5.6
       object.values: 1.2.1
       sax: 1.2.4


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-59869: Denial of Service via crafted YAML documents in `js-yaml` <3.15.0
- Adds `"js-yaml": "^3.15.0"` to `pnpm.overrides` in `frontend/package.json` to upgrade all transitive instances from 3.14.2 to 3.15.0
- Affected consumers: `eslint`, `cosmiconfig`, `@istanbuljs/load-nyc-config`, `svgo`

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 28 tests pass
- [x] Verified `pnpm-lock.yaml` contains no remaining references to `js-yaml@3.14.2`
- [ ] CI checks pass

Tracker: https://redhat.atlassian.net/browse/QUAYIO-1921

🤖 Generated with [Claude Code](https://claude.com/claude-code)